### PR TITLE
Autodeploy On New Tags

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,10 +38,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - uses: cowprotocol/autodeploy-action@v1
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
-          pods:
-                "ebbo"
+          pods: "ebbo"
           tag: ${{ secrets.AUTODEPLOY_TAG }}
           url: ${{ secrets.AUTODEPLOY_URL }}
           token: ${{ secrets.AUTODEPLOY_TOKEN }}


### PR DESCRIPTION
This PR changes the deployment GitHub action to trigger an auto-deploy only on new tags. The rationale for this change is that the `ebbo` deployment in our infrastructure is currently set to pull from the `latest` image, which only gets a new version every tag and not on every commit to the main branch.

The result of this change (hopefully - unless I got something wrong 🙈) is that every time a new GitHub release is made:
- A new image with tag `latest` is built
- The autodeploy hook will trigger a restart of the deployment such that the new image gets used