### PR TITLE
redirect to std output

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,12 +3,14 @@ Test Deployment File
 """
 import logging
 import time
+import sys
 
 
 def main() -> None:
     """Main Method"""
     logging.basicConfig(format="%(levelname)s - %(message)s")
     logger = logging.getLogger()
+    logger.addHandler(logging.StreamHandler(sys.stdout))
     logger.setLevel(logging.DEBUG)
     while True:
         logger.warning("CoW Protocol!")


### PR DESCRIPTION
This redirects the logs to std_out, with the hope to finally see something on kibana.