### PR TITLE
Require economic viability for alternative solutions

### DIFF
--- a/src/off_chain/cow_endpoint_surplus.py
+++ b/src/off_chain/cow_endpoint_surplus.py
@@ -191,10 +191,7 @@ class EBBOAnalysis:
                 surplus_deviation_dict = {}
                 soln_count = 0
                 for soln in competition_data["solutions"]:
-                    if (
-                        soln["objective"]["fees"] + 0.001 * pow(10, 18)
-                        < soln["objective"]["cost"]
-                    ):
+                    if soln["objective"]["fees"] < 0.9 * soln["objective"]["cost"]:
                         surplus_deviation_dict[soln_count] = 0.0, 0.0
                         soln_count += 1
                         continue

--- a/src/off_chain/cow_endpoint_surplus.py
+++ b/src/off_chain/cow_endpoint_surplus.py
@@ -191,7 +191,10 @@ class EBBOAnalysis:
                 surplus_deviation_dict = {}
                 soln_count = 0
                 for soln in competition_data["solutions"]:
-                    if soln["objective"]["total"] < 0:
+                    if (
+                        soln["objective"]["fees"] + 0.001 * pow(10, 18)
+                        < soln["objective"]["cost"]
+                    ):
                         surplus_deviation_dict[soln_count] = 0.0, 0.0
                         soln_count += 1
                         continue


### PR DESCRIPTION
With this PR, we ask that all alternative solutions considered must satisfy:

`collected_fees + 0.001 >= simulated_cost`.

Since simulated_cost is usually overestimating costs, should we instead require something like:

`collected_fees >= 0.9 * simulated_cost`?

**UPDATE:** Switched to the 2nd option, i.e., the relative check.