### PR TITLE
remove strict option from mypy

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -22,7 +22,7 @@ jobs:
         run:
           black --check ./
       - name: Type Check (mypy)
-        run: mypy src --strict
+        run: mypy src
       - name: Unit Tests
         run:
           python -m pytest tests/unit

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -35,7 +35,7 @@ class DaemonEBBO:
         """
         infura_connection = f"https://mainnet.infura.io/v3/{INFURA_KEY}"
         web_3 = Web3(Web3.HTTPProvider(infura_connection))
-        start_block = web_3.eth.block_number
+        start_block = int(web_3.eth.block_number)
         # self.logger.info("starting...")
         unchecked_hashes: List[str] = []
         while True:


### PR DESCRIPTION
This PR proposes to remove the `--strict` option from the mypy check.

At the current state of the repo, it slows things down significantly, and it is not clear if the benefits are that important for now. Of course, we want a stable monitoring tool, and eventually we should clean up the code and do proper type annotations, but now it seems it will take a very long time to have something working reasonably, partly because the --`strict` makes it much harder to merge PR #18, which adds fundamental functionality to the tool.