### PR TITLE
Make competition endpoint function available globally

### DIFF
--- a/src/daemon.py
+++ b/src/daemon.py
@@ -13,7 +13,11 @@ from typing import List
 from web3 import Web3
 from src.quasimodo_ebbo.on_chain_surplus import QuasimodoTestEBBO
 from src.off_chain.cow_endpoint_surplus import EndpointSolutionsEBBO
-from src.helper_functions import get_logger, get_tx_hashes_by_block, get_solver_competition_data
+from src.helper_functions import (
+    get_logger,
+    get_tx_hashes_by_block,
+    get_solver_competition_data,
+)
 from src.constants import INFURA_KEY
 from src.constants import SLEEP_TIME_IN_SEC
 
@@ -64,9 +68,7 @@ class DaemonEBBO:
         Function checks if solver competition data is retrievable and runs
         EBBO test, else returns True to add to list of unchecked hashes
         """
-        response_data = get_solver_competition_data(
-            [single_hash]
-        )
+        response_data = get_solver_competition_data([single_hash])
         if len(response_data) != 0:
             self.cow_endpoint_test_instance.get_order_surplus(response_data[0])
             return True

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -13,7 +13,7 @@ from typing import List
 from web3 import Web3
 from src.quasimodo_ebbo.on_chain_surplus import QuasimodoTestEBBO
 from src.off_chain.cow_endpoint_surplus import EndpointSolutionsEBBO
-from src.configuration import get_logger, get_tx_hashes_by_block
+from src.helper_functions import get_logger, get_tx_hashes_by_block, get_solver_competition_data
 from src.constants import INFURA_KEY
 from src.constants import SLEEP_TIME_IN_SEC
 
@@ -64,7 +64,7 @@ class DaemonEBBO:
         Function checks if solver competition data is retrievable and runs
         EBBO test, else returns True to add to list of unchecked hashes
         """
-        response_data = self.cow_endpoint_test_instance.get_solver_competition_data(
+        response_data = get_solver_competition_data(
             [single_hash]
         )
         if len(response_data) != 0:

--- a/src/helper_functions.py
+++ b/src/helper_functions.py
@@ -4,7 +4,7 @@ This file contains functions used by cow_endpoint_surplus and quasimodo_test_sur
 from __future__ import annotations
 import logging
 from fractions import Fraction
-from typing import List, Optional, Tuple, Any
+from typing import List, Optional, Tuple, Dict, Any
 from web3 import Web3
 
 
@@ -76,6 +76,47 @@ def percent_eth_conversions_order(
     diff_in_eth = (external_price / (pow(10, 18))) * (diff_surplus)
     # diff_in_eth = (external_price/(pow(10, 18))) * (diff_surplus/(pow(10, 18)))
     return percent_deviation, diff_in_eth
+
+
+def get_solver_competition_data(
+    self, settlement_hashes_list: List[str]
+) -> List[Dict[str, Any]]:
+    """
+    This function uses a list of tx hashes to fetch and assemble competition data
+    for each of the tx hashes and returns it.
+    """
+
+    solver_competition_data = []
+    for tx_hash in settlement_hashes_list:
+        try:
+            prod_endpoint_url = (
+                "https://api.cow.fi/mainnet/api/v1/solver_competition"
+                f"/by_tx_hash/{tx_hash}"
+            )
+            json_competition_data = requests.get(
+                prod_endpoint_url,
+                headers=header,
+                timeout=30,
+            )
+            if json_competition_data.status_code == SUCCESS_CODE:
+                solver_competition_data.append(json.loads(json_competition_data.text))
+                # print(tx_hash)
+            elif json_competition_data.status_code == FAIL_CODE:
+                barn_endpoint_url = (
+                    "https://barn.api.cow.fi/mainnet/api/v1"
+                    f"/solver_competition/by_tx_hash/{tx_hash}"
+                )
+                barn_competition_data = requests.get(
+                    barn_endpoint_url, headers=header, timeout=30
+                )
+                if barn_competition_data.status_code == SUCCESS_CODE:
+                    solver_competition_data.append(
+                        json.loads(barn_competition_data.text)
+                    )
+        except ValueError as except_err:
+            self.logger.error("Unhandled exception: %s.", str(except_err))
+
+    return solver_competition_data
 
 
 def get_surplus_order(

--- a/src/helper_functions.py
+++ b/src/helper_functions.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import logging
 from fractions import Fraction
 from typing import List, Optional, Tuple, Dict, Any
+import json
+import requests
 from web3 import Web3
-
-
-# from dune_client.client import DuneClient
-# from dune_client.query import Query
-from src.constants import ADDRESS
+from src.constants import (
+    header,
+    ADDRESS,
+    SUCCESS_CODE,
+    FAIL_CODE,
+)
 
 
 def get_logger(filename: Optional[str] = None) -> logging.Logger:
@@ -79,7 +82,7 @@ def percent_eth_conversions_order(
 
 
 def get_solver_competition_data(
-    self, settlement_hashes_list: List[str]
+    settlement_hashes_list: List[str],
 ) -> List[Dict[str, Any]]:
     """
     This function uses a list of tx hashes to fetch and assemble competition data
@@ -87,6 +90,7 @@ def get_solver_competition_data(
     """
 
     solver_competition_data = []
+    logger = get_logger()
     for tx_hash in settlement_hashes_list:
         try:
             prod_endpoint_url = (
@@ -114,7 +118,7 @@ def get_solver_competition_data(
                         json.loads(barn_competition_data.text)
                     )
         except ValueError as except_err:
-            self.logger.error("Unhandled exception: %s.", str(except_err))
+            logger.error("Unhandled exception: %s.", str(except_err))
 
     return solver_competition_data
 

--- a/src/off_chain/cow_endpoint_surplus.py
+++ b/src/off_chain/cow_endpoint_surplus.py
@@ -73,49 +73,7 @@ class EndpointSolutionsEBBO:
         for comp_data in solver_competition_data:
             self.get_order_surplus(comp_data)
 
-    def get_solver_competition_data(
-        self, settlement_hashes_list: List[str]
-    ) -> List[Dict[str, Any]]:
-        """
-        This function uses a list of tx hashes to fetch and assemble competition data
-        for each of the tx hashes and returns it to get_surplus_by_input for further
-        surplus calculation.
-        """
-
-        solver_competition_data = []
-        for tx_hash in settlement_hashes_list:
-            try:
-                prod_endpoint_url = (
-                    "https://api.cow.fi/mainnet/api/v1/solver_competition"
-                    f"/by_tx_hash/{tx_hash}"
-                )
-                json_competition_data = requests.get(
-                    prod_endpoint_url,
-                    headers=header,
-                    timeout=30,
-                )
-                if json_competition_data.status_code == SUCCESS_CODE:
-                    solver_competition_data.append(
-                        json.loads(json_competition_data.text)
-                    )
-                    # print(tx_hash)
-                elif json_competition_data.status_code == FAIL_CODE:
-                    barn_endpoint_url = (
-                        "https://barn.api.cow.fi/mainnet/api/v1"
-                        f"/solver_competition/by_tx_hash/{tx_hash}"
-                    )
-                    barn_competition_data = requests.get(
-                        barn_endpoint_url, headers=header, timeout=30
-                    )
-                    if barn_competition_data.status_code == SUCCESS_CODE:
-                        solver_competition_data.append(
-                            json.loads(barn_competition_data.text)
-                        )
-            except ValueError as except_err:
-                self.logger.error("Unhandled exception: %s.", str(except_err))
-
-        return solver_competition_data
-
+ 
     def get_decoded_settlement(self, tx_hash: str):
         """
         Takes settlement hash as input, returns decoded settlement data.

--- a/src/off_chain/cow_endpoint_surplus.py
+++ b/src/off_chain/cow_endpoint_surplus.py
@@ -3,28 +3,24 @@ This class is the first component of the EBBO Monitoring Suite. Orders of the wi
 settlement are tested for EBBO relative to all other solutions provided.
 Competition Data is fetched via the CoW API.
 """
-import json
 import traceback
 from typing import List, Dict, Tuple, Any, Optional
 from eth_typing import Address, HexStr
 from hexbytes import HexBytes
 from web3 import Web3
-import requests
-from src.configuration import (
+from src.helper_functions import (
     get_logger,
     get_tx_hashes_by_block,
     get_surplus_order,
     percent_eth_conversions_order,
+    get_solver_competition_data,
 )
 from src.quasimodo_ebbo.on_chain_surplus import DecodedSettlement
 from src.constants import (
     INFURA_KEY,
-    header,
     ADDRESS,
     ABSOLUTE_ETH_FLAG_AMOUNT,
     REL_DEVIATION_FLAG_PERCENT,
-    SUCCESS_CODE,
-    FAIL_CODE,
 )
 from contracts.gpv2_settlement import gpv2_settlement as gpv2Abi
 
@@ -67,13 +63,10 @@ class EndpointSolutionsEBBO:
         if not settlement_hashes_list:
             raise ValueError("No settlement hashes found")
 
-        solver_competition_data = self.get_solver_competition_data(
-            settlement_hashes_list
-        )
+        solver_competition_data = get_solver_competition_data(settlement_hashes_list)
         for comp_data in solver_competition_data:
             self.get_order_surplus(comp_data)
 
- 
     def get_decoded_settlement(self, tx_hash: str):
         """
         Takes settlement hash as input, returns decoded settlement data.

--- a/src/quasimodo_ebbo/on_chain_surplus.py
+++ b/src/quasimodo_ebbo/on_chain_surplus.py
@@ -12,7 +12,7 @@ from eth_typing import Address, HexStr
 from hexbytes import HexBytes
 import requests
 from web3 import Web3
-from src.configuration import (
+from src.helper_functions import (
     get_logger,
     get_tx_hashes_by_block,
     get_surplus_order,

--- a/src/quasimodo_ebbo/on_chain_surplus.py
+++ b/src/quasimodo_ebbo/on_chain_surplus.py
@@ -79,11 +79,11 @@ class QuasimodoTestEBBO:
         for settlement_hash in settlement_hashes_list:
             self.process_single_hash(settlement_hash)
 
-    def process_single_hash(self, settlement_hash: str) -> Optional[bool]:
+    def process_single_hash(self, settlement_hash: str) -> bool:
         """
-        Goes through all settlements fetched, decodes orders,
-        gets response from AWS bucket.
-        Returns `None` in case data cannot be fetched, a not-None value "True" otherwise.
+        Goes over all orders in the winning settlement, decodes orders,
+        gets response from AWS bucket, and runs the main Quasimodo test for each order.
+        Returns FALSE in case data cannot be fetched, and TRUE, otherwise.
         """
         try:
             encoded_transaction = self.web_3.eth.get_transaction(


### PR DESCRIPTION
This PR makes the function that gathers all data for a single settlement from the competition endpoint available globally. It also renames the `configuration.py` file to the more appropriate `helper_functions.py`