### PR TITLE
Quote test ignores some errors now

### DIFF
--- a/src/monitoring_tests/fee_monitoring/fee_monitoring.py
+++ b/src/monitoring_tests/fee_monitoring/fee_monitoring.py
@@ -14,7 +14,8 @@ class FeeMonitoring:
     Class for fee monitoring.
     """
 
-    def fee_test(self, tx_hash) -> bool:  # pylint: disable=too-many-locals
+    def fee_test(self, tx_hash) -> bool:
+        # pylint: disable=too-many-locals, too-many-branches
         """
         Given a transaction hash, check if there is a partially-fillable order in the settlement.
         If this is the case, perform multiple tests on the execution of those orders to check if

--- a/src/monitoring_tests/fee_monitoring/fee_monitoring.py
+++ b/src/monitoring_tests/fee_monitoring/fee_monitoring.py
@@ -66,9 +66,11 @@ class FeeMonitoring:
                         quote_fee_amount,
                     ) = TemplateTest.get_quote(decoded_settlement, i)
                 except ConnectionError as err:
-                    TemplateTest.logger.error("Error fetching quote: %s", err)
+                    TemplateTest.logger.error("ConnectionError fetching quote: %s", err)
                     return False
-
+                except ValueError as err:
+                    TemplateTest.logger.error("ValueError fetching quote: %s.", err)
+                    return True
                 try:
                     gas_price_quote = TemplateTest.get_current_gas_price()
                 except ValueError as err:

--- a/src/monitoring_tests/template_test.py
+++ b/src/monitoring_tests/template_test.py
@@ -309,18 +309,29 @@ class TemplateTest:
                 json=request_dict,
                 timeout=30,
             )
-            if quote_response.status_code != SUCCESS_CODE:
+        except ValueError as err:
+            cls.logger.error("Fee quote failed with error %s.", err)
+
+        if quote_response.status_code != SUCCESS_CODE:
+            error_type = json.loads(quote_response.content)["errorType"]
+            error_description = json.loads(quote_response.content)["description"]
+            if error_type in ("SellAmountDoesNotCoverFee", "NoLiquidity"):
                 cls.logger.error(
-                    "Error %s getting quote for trade %s",
+                    "Error %s, %s while getting quote for trade %s",
                     quote_response.status_code,
+                    error_description,
                     trade,
                 )
-                raise ConnectionError(
-                    f"Fee quote failed with error {quote_response.status_code}"
-                )
-        except ValueError as except_err:
-            TemplateTest.logger.error(
-                "Unhandled exception when fetching quotes: %s.", str(except_err)
+                raise ValueError(error_description)
+
+            cls.logger.error(
+                "Error %s, %s while getting quote for trade %s",
+                quote_response.status_code,
+                error_description,
+                trade,
+            )
+            raise ConnectionError(
+                f"Fee quote failed with error {quote_response.status_code}, {error_description}"
             )
 
         quote_json = json.loads(quote_response.text)

--- a/src/monitoring_tests/template_test.py
+++ b/src/monitoring_tests/template_test.py
@@ -272,6 +272,7 @@ class TemplateTest:
 
     @classmethod
     def get_quote(cls, decoded_settlement, i) -> Tuple[int, int, int]:
+        # pylint: disable=too-many-locals
         """
         Given a trade, compute buy_amount, sell_amount, and fee_amount of the trade
         as proposed by our quoting infrastructure.

--- a/tests/e2e/test.py
+++ b/tests/e2e/test.py
@@ -29,11 +29,15 @@ class TestFeeMonitoring(unittest.TestCase):
         """
         Test that function works with a hash
         """
+        instance = FeeMonitoring()
         # tx_hash = "0xb1add23c49fc99f1471b61e48a1f0e6eb18f88d190144cea80dfc290ad0bcc98"
-        # tx_hash = "0xf467a6a01f61fa608c1bc116e2f4f4df1b95461827b1e7700c1d36628875feab"
+        tx_hash = "0xf467a6a01f61fa608c1bc116e2f4f4df1b95461827b1e7700c1d36628875feab"
+        self.assertTrue(instance.fee_test(tx_hash))
         # buy order:
         tx_hash = "0x8e9f98cabf9b6ff4e001eda5efacfd70590a60bd03a499d8b02130b67b208eb1"
-        instance = FeeMonitoring()
+        self.assertTrue(instance.fee_test(tx_hash))
+        # small executed amount:
+        tx_hash = "0xda857a0db563dae564b09febb683fff6150628c1706afc9ebd961c194ca29c5e"
         self.assertTrue(instance.fee_test(tx_hash))
 
 


### PR DESCRIPTION
The hash 0xda857a0db563dae564b09febb683fff6150628c1706afc9ebd961c194ca29c5e
contains a partially-fillable order with an executed amount which is too small
to pay for fees. This resulted in the hash being rechecked over and over.
This error is now handled by logging an error and letting the test succeed.

This catches the errors `'NoLiquidity'` and `'SellAmountDoesNotCoverFees'`.