### PR TITLE
Change handling of quasimodo error

### DIFF
--- a/src/monitoring_tests/reference_solver_surplus_test.py
+++ b/src/monitoring_tests/reference_solver_surplus_test.py
@@ -54,11 +54,11 @@ class ReferenceSolverSurplusTest(BaseTest):
 
             trade_alt = self.get_trade_alternative(uid, auction_instance)
             if trade_alt is None:
-                self.logger.error(
+                self.logger.warning(
                     f"No alternative trade for uid {uid} and "
                     f"auction id {auction_instance['metadata']['auction_id']}"
                 )
-                return False
+                return True
             if trade_alt.execution.buy_amount == 0:
                 continue
 


### PR DESCRIPTION
If quasimodo does not return a valid response, instead of emitting an error and retrying a hash, we now emit a warning and do not try the hash again.
This is just a hotfix. To solve the underlying issue, we should
- add error handling using custom exceptions
- let tests fail gracefully by removing hashes after some retries
- find the bug in how we call quasimodo