### PR TITLE
Log reference solver (i.e., Quasimodo) solution when generating a ref_solver-surplus-ebbo error

### DIFF
--- a/src/apis/solverapi.py
+++ b/src/apis/solverapi.py
@@ -66,7 +66,7 @@ class SolverAPI:
         """
         orders = solution["orders"]
         if len(orders) == 1:
-            _, order_dict = solution["orders"].popitem()
+            (order_dict,) = solution["orders"].values()
             execution = self.get_execution_from_order(order_dict)
         elif len(orders) == 0:
             self.logger.debug("Trivial solution found.")

--- a/src/monitoring_tests/reference_solver_surplus_test.py
+++ b/src/monitoring_tests/reference_solver_surplus_test.py
@@ -119,7 +119,7 @@ class ReferenceSolverSurplusTest(BaseTest):
 
     def get_trade_alternative(
         self, uid: str, auction_instance: dict[str, Any], solution: dict[str, Any]
-    ) -> Optional[Trade]:
+    ) -> Trade:
         """Parse alternative execution for an order with uid as settled by a reference solver
         given the liquidity in auction_instance.
         """

--- a/src/monitoring_tests/reference_solver_surplus_test.py
+++ b/src/monitoring_tests/reference_solver_surplus_test.py
@@ -61,7 +61,9 @@ class ReferenceSolverSurplusTest(BaseTest):
                     f"auction id {auction_instance['metadata']['auction_id']}"
                 )
                 return True
-            trade_alt = self.get_trade_alternative(uid, auction_instance, solution)
+            trade_alt = self.get_trade_alternative(
+                uid, auction_instance, ref_solver_response
+            )
             if trade_alt.execution.buy_amount == 0:
                 continue
 
@@ -84,7 +86,7 @@ class ReferenceSolverSurplusTest(BaseTest):
                 [
                     f"Tx Hash: {competition_data['transactionHash']}",
                     f"Order UID: {uid}",
-                    f"Solution providing more surplus: {solution}",
+                    f"Solution providing more surplus: {ref_solver_response}",
                 ]
             )
 

--- a/src/monitoring_tests/reference_solver_surplus_test.py
+++ b/src/monitoring_tests/reference_solver_surplus_test.py
@@ -33,8 +33,8 @@ class ReferenceSolverSurplusTest(BaseTest):
     ) -> bool:
         """
         This function goes through each order that the winning solution executed
-        and finds non-winning solutions that executed the same order and
-        calculates surplus difference between that pair (winning and non-winning solution).
+        and compares its execution with the execution of that order by
+        a reference solver.
         """
 
         solution = competition_data["solutions"][-1]
@@ -52,14 +52,16 @@ class ReferenceSolverSurplusTest(BaseTest):
                 10**36,
             )
 
-            ref_solver_response = self.get_trade_alternative(uid, auction_instance)
+            ref_solver_response = self.solve_order_with_reference_solver(
+                uid, auction_instance
+            )
             if ref_solver_response is None:
-                self.logger.warning(
-                    f"No alternative trade for uid {uid} and "
+                self.logger.debug(
+                    f"No reference solution for uid {uid} and "
                     f"auction id {auction_instance['metadata']['auction_id']}"
                 )
                 return True
-            trade_alt = ref_solver_response[0]
+            trade_alt = self.get_trade_alternative(uid, auction_instance, solution)
             if trade_alt.execution.buy_amount == 0:
                 continue
 
@@ -82,8 +84,7 @@ class ReferenceSolverSurplusTest(BaseTest):
                 [
                     f"Tx Hash: {competition_data['transactionHash']}",
                     f"Order UID: {uid}",
-                    "Solution providing more surplus",
-                    str(ref_solver_response[1]),
+                    f"Solution providing more surplus: {solution}",
                 ]
             )
 
@@ -103,29 +104,29 @@ class ReferenceSolverSurplusTest(BaseTest):
 
         return True
 
-    def get_trade_alternative(
+    def solve_order_with_reference_solver(
         self, uid: str, auction_instance: dict[str, Any]
-    ) -> Optional[tuple[Trade, dict[str, Any]]]:
-        """Compute alternative execution for an order with uid as settled by a reference solver
+    ) -> Optional[dict[str, Any]]:
+        """Compute solution json for an order with uid as settled by a reference solver
         given the liquidity in auction_instance.
         """
-        data = self.auction_instance_api.get_order_data(uid, auction_instance)
         order_auction_instance = (
             self.auction_instance_api.generate_reduced_single_order_auction_instance(
                 uid, auction_instance
             )
         )
+        return self.solver_api.solve_instance(order_auction_instance)
 
-        solution = self.solver_api.solve_instance(order_auction_instance)
-        if solution is None:
-            self.logger.debug(
-                f"No reference solution for uid {uid} and "
-                f"auction id {auction_instance['metadata']['auction_id']}"
-            )
-            return None
+    def get_trade_alternative(
+        self, uid: str, auction_instance: dict[str, Any], solution: dict[str, Any]
+    ) -> Optional[Trade]:
+        """Parse alternative execution for an order with uid as settled by a reference solver
+        given the liquidity in auction_instance.
+        """
+        data = self.auction_instance_api.get_order_data(uid, auction_instance)
         execution = self.solver_api.get_execution_from_solution(solution)
 
-        return (Trade(data, execution), solution)
+        return Trade(data, execution)
 
     def get_uid_trades(self, solution: dict[str, Any]) -> dict[str, Trade]:
         """Get a dictionary mapping UIDs to trades in a solution."""

--- a/src/monitoring_tests/reference_solver_surplus_test.py
+++ b/src/monitoring_tests/reference_solver_surplus_test.py
@@ -82,7 +82,8 @@ class ReferenceSolverSurplusTest(BaseTest):
                 [
                     f"Tx Hash: {competition_data['transactionHash']}",
                     f"Order UID: {uid}",
-                    f"Solution providing more surplus",
+                    "Solution providing more surplus",
+                    str(ref_solver_response[1]),
                 ]
             )
 
@@ -91,7 +92,7 @@ class ReferenceSolverSurplusTest(BaseTest):
                 and a_rel > SURPLUS_REL_DEVIATION
             ):
                 self.alert(log_output)
-                self.logger.info(ref_solver_log + str(ref_solver_response[1]))
+                self.logger.info(ref_solver_log)
             elif (
                 a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH / 10
                 and a_rel > SURPLUS_REL_DEVIATION / 10
@@ -124,7 +125,7 @@ class ReferenceSolverSurplusTest(BaseTest):
             return None
         execution = self.solver_api.get_execution_from_solution(solution)
 
-        return (Trade(data, execution),solution)
+        return (Trade(data, execution), solution)
 
     def get_uid_trades(self, solution: dict[str, Any]) -> dict[str, Trade]:
         """Get a dictionary mapping UIDs to trades in a solution."""

--- a/src/monitoring_tests/reference_solver_surplus_test.py
+++ b/src/monitoring_tests/reference_solver_surplus_test.py
@@ -61,7 +61,7 @@ class ReferenceSolverSurplusTest(BaseTest):
                     f"auction id {auction_instance['metadata']['auction_id']}"
                 )
                 return True
-            trade_alt = self.get_trade_alternative(
+            trade_alt = self.get_trade_information(
                 uid, auction_instance, ref_solver_response
             )
             if trade_alt.execution.buy_amount == 0:
@@ -119,10 +119,10 @@ class ReferenceSolverSurplusTest(BaseTest):
         )
         return self.solver_api.solve_instance(order_auction_instance)
 
-    def get_trade_alternative(
+    def get_trade_information(
         self, uid: str, auction_instance: dict[str, Any], solution: dict[str, Any]
     ) -> Trade:
-        """Parse alternative execution for an order with uid as settled by a reference solver
+        """Parse execution for an order with uid as settled by a reference solver
         given the liquidity in auction_instance.
         """
         data = self.auction_instance_api.get_order_data(uid, auction_instance)


### PR DESCRIPTION
This PR adds logging of the solution generated by the reference solver, whenever this (in isolation) gives more surplus to an order that is executed by some solver in the competition.