### PR TITLE
Add new score reporting to cost coverage test

### DIFF
--- a/src/monitoring_tests/cost_coverage_per_solver_test.py
+++ b/src/monitoring_tests/cost_coverage_per_solver_test.py
@@ -50,6 +50,8 @@ class CostCoveragePerSolverTest(BaseTest):
                 ref_score_str = second_best_sol["score"]
             elif "scoreDiscounted" in second_best_sol:
                 ref_score_str = second_best_sol["scoreDiscounted"]
+            elif "scoreProtocolWithSolverRisk" in second_best_sol:
+                ref_score_str = second_best_sol["scoreProtocolWithSolverRisk"]
             else:
                 ref_score_str = second_best_sol["scoreProtocol"]
             ref_score = float(int(ref_score_str) / 10**18)


### PR DESCRIPTION
Fixes #71 by adding one more case to an `if ... else` block.

This was tested locally for specific hashes (e.g. `0x71cefc37510c2e00e4d345c0cf84afc7dfd0f397f39275211ea662e355a1fb6e`) where the test failed before.