### PR TITLE
Mute most alerts

### DIFF
--- a/src/monitoring_tests/partially_fillable_fee_quote_test.py
+++ b/src/monitoring_tests/partially_fillable_fee_quote_test.py
@@ -93,7 +93,7 @@ class PartialFillFeeQuoteTest(BaseTest):
         ]
 
         if abs(diff_fee_rel) > FEE_RELATIVE_DEVIATION_FLAG:
-            self.alert("\t".join(log_output))
+            self.logger.info("\t".join(log_output))
         elif abs(diff_fee_rel) > FEE_RELATIVE_DEVIATION_FLAG / 10:
             self.logger.info("\t".join(log_output))
         else:

--- a/src/monitoring_tests/reference_solver_surplus_test.py
+++ b/src/monitoring_tests/reference_solver_surplus_test.py
@@ -94,7 +94,7 @@ class ReferenceSolverSurplusTest(BaseTest):
                 a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH
                 and a_rel > SURPLUS_REL_DEVIATION
             ):
-                self.alert(log_output)
+                self.logger.info(log_output)
                 self.logger.info(ref_solver_log)
             elif (
                 a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH / 10

--- a/src/monitoring_tests/solver_competition_surplus_test.py
+++ b/src/monitoring_tests/solver_competition_surplus_test.py
@@ -69,7 +69,6 @@ class SolverCompetitionSurplusTest(BaseTest):
                 if (
                     a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH
                     and a_rel > SURPLUS_REL_DEVIATION
-                    and solver_alt == "BaselineSolver"
                 ):
                     self.alert(log_output)
                 elif (

--- a/src/monitoring_tests/solver_competition_surplus_test.py
+++ b/src/monitoring_tests/solver_competition_surplus_test.py
@@ -69,6 +69,7 @@ class SolverCompetitionSurplusTest(BaseTest):
                 if (
                     a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH
                     and a_rel > SURPLUS_REL_DEVIATION
+                    and solver_alt == "BaselineSolver"
                 ):
                     self.alert(log_output)
                 elif (


### PR DESCRIPTION
This PR mutes most alerts currently raised in the repo:
- All alerts from the quote test are removed.
- All alerts form the reference solver test are removed.
- ~In the solver competition test, only those violations raise an alert where the reference solver is BaselineSolver.~ (edit: the solver competition test was not changed)

The test on cost coverage for partially fillable orders and the summary on cost coverage per solver (edit: and the solver competition test) are not changed. They will be relevant for the upcomming changes with regards to letting solvers choose fees.

This is another attempt at addressing #59.