### PR TITLE
[EASY] Remove score discount code path

### DIFF
--- a/src/monitoring_tests/cost_coverage_per_solver_test.py
+++ b/src/monitoring_tests/cost_coverage_per_solver_test.py
@@ -48,8 +48,6 @@ class CostCoveragePerSolverTest(BaseTest):
             second_best_sol = competition_data["solutions"][-2]
             if "score" in second_best_sol:
                 ref_score_str = second_best_sol["score"]
-            elif "scoreDiscounted" in second_best_sol:
-                ref_score_str = second_best_sol["scoreDiscounted"]
             elif "scoreProtocolWithSolverRisk" in second_best_sol:
                 ref_score_str = second_best_sol["scoreProtocolWithSolverRisk"]
             else:


### PR DESCRIPTION
This PR removes the score discount code path as there is no such option for submitting a score anymore. This closes issue #73 .