### PR TITLE
[EASY] Web3 API update: Get block number from tx hash

### DIFF
--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -85,7 +85,17 @@ class Web3API:
             transaction = None
 
         return transaction
-
+    
+    def get_tx_block_number(self, tx_hash: str) -> Optional[int]:
+        """
+        Takes tx hash as input, returns block number where tx took place.
+        """
+        transaction = self.get_transaction(tx_hash)
+        if transaction is None:
+            return None
+        else:
+            return transaction['blockNumber']
+    
     def get_receipt(self, tx_hash: str) -> Optional[TxReceipt]:
         """
         Get the receipt of a transaction from the transaction hash.

--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -85,7 +85,7 @@ class Web3API:
             transaction = None
 
         return transaction
-    
+
     def get_tx_block_number(self, tx_hash: str) -> Optional[int]:
         """
         Takes tx hash as input, returns block number where tx took place.
@@ -94,8 +94,8 @@ class Web3API:
         if transaction is None:
             return None
         else:
-            return transaction['blockNumber']
-    
+            return transaction["blockNumber"]
+
     def get_receipt(self, tx_hash: str) -> Optional[TxReceipt]:
         """
         Get the receipt of a transaction from the transaction hash.

--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -93,8 +93,7 @@ class Web3API:
         transaction = self.get_transaction(tx_hash)
         if transaction is None:
             return None
-        else:
-            return transaction["blockNumber"]
+        return transaction["blockNumber"]
 
     def get_receipt(self, tx_hash: str) -> Optional[TxReceipt]:
         """


### PR DESCRIPTION
This PR adds a very simple function in the web3, where one can provide a tx hash and gets back the block number where the tx took place.

(Context: I would like to fetch the block number so that I can then search for MEV Blocker kickbacks within that block)