### PR TITLE
Update web3 api to compute eth transfers to an address

### DIFF
--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -28,7 +28,7 @@ class Web3API:
             self.url = getenv("NODE_URL")
         else:
             infura_key = getenv("INFURA_KEY")
-            #self.url = f"https://mainnet.infura.io/v3/{infura_key}"
+            # self.url = f"https://mainnet.infura.io/v3/{infura_key}"
             self.url = "https://mainnet.infura.io/v3/ec46e54a3d5a41e4930952e54bd0cd51"
         self.web_3 = Web3(Web3.HTTPProvider(self.url))
         self.contract = self.web_3.eth.contract(
@@ -89,7 +89,7 @@ class Web3API:
         self, start_block: int, end_block: int, target: str
     ) -> Optional[float]:
         """
-        Function that computes total eth transfers to a target address
+        Function that computes total eth transfers to a target Safe address
         within a certain block range
         """
         log_receipts = self.get_filtered_receipts(start_block, end_block, target, [])
@@ -97,7 +97,10 @@ class Web3API:
             return None
         total_transfers_in_eth = 0.0
         for txs in log_receipts:
-            if txs["topics"][0].hex() == "0x3d0ce9bfc3ed7d6862dbb28b2dea94561fe714a1b4d019aa8af39730d1ad7c3d":
+            if (
+                txs["topics"][0].hex()
+                == "0x3d0ce9bfc3ed7d6862dbb28b2dea94561fe714a1b4d019aa8af39730d1ad7c3d"
+            ):
                 total_transfers_in_eth += int(txs["data"].hex(), 16) / 10**18
         return total_transfers_in_eth
 

--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -47,7 +47,7 @@ class Web3API:
 
     def get_filtered_receipts(
         self, start_block: int, end_block: int, target: str, topics: list[Any] = []
-    ) -> Optional[list[Any]]:
+    ) -> list[Any]:
         """
         Function filters receipts by contract address, and block ranges
         """
@@ -87,7 +87,7 @@ class Web3API:
     def get_incoming_eth_transfers_to_contract_within_block_range(
         self, start_block: int, end_block: int, target: str
     ) -> Optional[int]:
-        log_receipts = self.get_filtered_receipts(start_block, end_block, target)
+        log_receipts = self.get_filtered_receipts(start_block, end_block, target, [])
         if log_receipts is None:
             return None
         total_transfers_in_eth = 0

--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -46,8 +46,8 @@ class Web3API:
             return None
 
     def get_filtered_receipts(
-        self, start_block: int, end_block: int, target: str, topics: list[Any] = []
-    ) -> list[Any]:
+        self, start_block: int, end_block: int, target: str, topics: list[Any]
+    ) -> Optional[list[Any]]:
         """
         Function filters receipts by contract address, and block ranges
         """

--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -84,7 +84,7 @@ class Web3API:
         )
         return settlement_hashes_list
 
-    def get_incoming_eth_transfers_to_contract_within_block_range(
+    def get_eth_transfers_by_block_range(
         self, start_block: int, end_block: int, target: str
     ) -> Optional[float]:
         """

--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -86,7 +86,7 @@ class Web3API:
 
     def get_incoming_eth_transfers_to_contract_within_block_range(
         self, start_block: int, end_block: int, target: str
-    ) -> Optional[int]:
+    ) -> Optional[float]:
         """
         Function that computes total eth transfers to a target address
         within a certain block range

--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -28,8 +28,7 @@ class Web3API:
             self.url = getenv("NODE_URL")
         else:
             infura_key = getenv("INFURA_KEY")
-            # self.url = f"https://mainnet.infura.io/v3/{infura_key}"
-            self.url = "https://mainnet.infura.io/v3/ec46e54a3d5a41e4930952e54bd0cd51"
+            self.url = f"https://mainnet.infura.io/v3/{infura_key}"
         self.web_3 = Web3(Web3.HTTPProvider(self.url))
         self.contract = self.web_3.eth.contract(
             address=Address(HexBytes(SETTLEMENT_CONTRACT_ADDRESS)), abi=gpv2_settlement

--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -87,6 +87,10 @@ class Web3API:
     def get_incoming_eth_transfers_to_contract_within_block_range(
         self, start_block: int, end_block: int, target: str
     ) -> Optional[int]:
+        """
+        Function that computes total eth transfers to a target address
+        within a certain block range
+        """
         log_receipts = self.get_filtered_receipts(start_block, end_block, target, [])
         if log_receipts is None:
             return None

--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -94,7 +94,7 @@ class Web3API:
         log_receipts = self.get_filtered_receipts(start_block, end_block, target, [])
         if log_receipts is None:
             return None
-        total_transfers_in_eth = 0
+        total_transfers_in_eth = 0.0
         for txs in log_receipts:
             total_transfers_in_eth += int(txs["data"].hex(), 16) / 10**18
         return total_transfers_in_eth

--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -96,9 +96,9 @@ class Web3API:
         if log_receipts is None:
             return None
         total_transfers_in_eth = 0.0
-        for tx in log_receipts:
-            if tx["topics"][0].hex() == "0x3d0ce9bfc3ed7d6862dbb28b2dea94561fe714a1b4d019aa8af39730d1ad7c3d":
-                total_transfers_in_eth += int(tx["data"].hex(), 16) / 10**18
+        for txs in log_receipts:
+            if txs["topics"][0].hex() == "0x3d0ce9bfc3ed7d6862dbb28b2dea94561fe714a1b4d019aa8af39730d1ad7c3d":
+                total_transfers_in_eth += int(txs["data"].hex(), 16) / 10**18
         return total_transfers_in_eth
 
     def get_transaction(self, tx_hash: str) -> Optional[TxData]:

--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -28,7 +28,8 @@ class Web3API:
             self.url = getenv("NODE_URL")
         else:
             infura_key = getenv("INFURA_KEY")
-            self.url = f"https://mainnet.infura.io/v3/{infura_key}"
+            #self.url = f"https://mainnet.infura.io/v3/{infura_key}"
+            self.url = "https://mainnet.infura.io/v3/ec46e54a3d5a41e4930952e54bd0cd51"
         self.web_3 = Web3(Web3.HTTPProvider(self.url))
         self.contract = self.web_3.eth.contract(
             address=Address(HexBytes(SETTLEMENT_CONTRACT_ADDRESS)), abi=gpv2_settlement
@@ -95,8 +96,9 @@ class Web3API:
         if log_receipts is None:
             return None
         total_transfers_in_eth = 0.0
-        for txs in log_receipts:
-            total_transfers_in_eth += int(txs["data"].hex(), 16) / 10**18
+        for tx in log_receipts:
+            if tx["topics"][0].hex() == "0x3d0ce9bfc3ed7d6862dbb28b2dea94561fe714a1b4d019aa8af39730d1ad7c3d":
+                total_transfers_in_eth += int(tx["data"].hex(), 16) / 10**18
         return total_transfers_in_eth
 
     def get_transaction(self, tx_hash: str) -> Optional[TxData]:


### PR DESCRIPTION
This PR adjusts a bit some of the functionality of the web3 api and adds a function that computes the native eth transfers to a target address. This again is needed for the PR that tracks the MEV Blocker kickbacks (that will be a follow-up to this PR).