### PR TITLE
Test comparable to combinatorial auction filtering

### DIFF
--- a/src/daemon.py
+++ b/src/daemon.py
@@ -24,6 +24,9 @@ from src.monitoring_tests.reference_solver_surplus_test import (
 from src.monitoring_tests.cost_coverage_per_solver_test import (
     CostCoveragePerSolverTest,
 )
+from src.monitoring_tests.combinatorial_auction_surplus_test import (
+    CombinatorialAuctionSurplusTest,
+)
 from src.constants import SLEEP_TIME_IN_SEC
 
 
@@ -40,6 +43,7 @@ def main() -> None:
         PartialFillFeeQuoteTest(),
         PartialFillCostCoverageTest(),
         CostCoveragePerSolverTest(),
+        CombinatorialAuctionSurplusTest(),
     ]
 
     start_block: Optional[int] = None

--- a/src/monitoring_tests/combinatorial_auction_surplus_test.py
+++ b/src/monitoring_tests/combinatorial_auction_surplus_test.py
@@ -135,7 +135,6 @@ class CombinatorialAuctionSurplusTest(BaseTest):
         large costs.
         """
         trades_dict = self.get_uid_trades(solution)
-        objective = solution["objective"]["total"]
         surplus_dict: dict[tuple[str, str], Fraction] = {}
         for uid in trades_dict:
             trade = trades_dict[uid]
@@ -161,7 +160,10 @@ class CombinatorialAuctionSurplusTest(BaseTest):
         # use the minimum of surplus and objective in case there is only one token pair
         if len(surplus_dict) == 1:
             for token_pair in surplus_dict:
-                surplus_dict[token_pair] = min(surplus_dict[token_pair], objective)
+                surplus_dict[token_pair] = min(
+                    surplus_dict[token_pair], solution["objective"]["total"]
+                )
+                # surplus_dict[token_pair] = solution["objective"]["total"]
 
         return surplus_dict
 

--- a/src/monitoring_tests/combinatorial_auction_surplus_test.py
+++ b/src/monitoring_tests/combinatorial_auction_surplus_test.py
@@ -10,13 +10,27 @@ from src.monitoring_tests.base_test import BaseTest
 from src.apis.web3api import Web3API
 from src.apis.orderbookapi import OrderbookAPI
 from src.models import Trade
-from src.constants import SURPLUS_ABSOLUTE_DEVIATION_ETH, SURPLUS_REL_DEVIATION
+from src.constants import SURPLUS_ABSOLUTE_DEVIATION_ETH
 
 
 class CombinatorialAuctionSurplusTest(BaseTest):
-    """
-    This test compares the surplus all orders from the winning settlement to
-    the different executions of these orders by other solvers in the competition.
+    """Test how a combinatorial auctions would have settled the auction.
+    This test implements a logic for a combinatorial auction and compares the result to what
+    actually happened.
+
+    The combinatorial auction goes as follows:
+    - Aggregate surplus on the different directed sell token-buy token pairs for all solutions in
+      the competition.
+    - Compute a baseline for surplus on all token pairs from those solutions.
+    - Filter solutions which to not provide at least as much surplus as the baseline on all token
+      pairs.
+    - Choose one batch winner and multiple single order winners.
+
+    The test logs an output whenever
+    - the winner of the solver competition would have been filtered out in a combinatorial auction
+      or
+    - the total surplus in a combinatorial auction would have been significantly larger than it was
+      with our current mechanism.
     """
 
     def __init__(self) -> None:
@@ -31,56 +45,51 @@ class CombinatorialAuctionSurplusTest(BaseTest):
         It then calculates surplus difference between the winning and non-winning solution.
         """
 
+        solutions = competition_data["solutions"]
+        solution = competition_data["solutions"][-1]
+
         aggregate_solutions = [
             self.get_token_pairs_surplus(
                 solution, competition_data["auction"]["prices"]
             )
-            for solution in competition_data["solutions"]
+            for solution in solutions
         ]
         aggregate_solution = aggregate_solutions[-1]
 
-        for token_pair, token_pair_surplus in aggregate_solution.items():
-            for i, aggregate_solution_alt in enumerate(aggregate_solutions[0:-1]):
-                if len(aggregate_solution_alt) == 1:
-                    if token_pair in aggregate_solution_alt:
-                        solution = competition_data["solutions"][-1]
-                        solution_alt = competition_data["solutions"][i]
+        baseline_surplus = self.compute_baseline_surplus(aggregate_solutions)
+        filter_mask = self.filter_solutions(aggregate_solutions, baseline_surplus)
+        winning_solutions = self.determine_winning_solutions(
+            aggregate_solutions, baseline_surplus, filter_mask
+        )
+        winning_solvers = self.determine_winning_solvers(
+            solutions, aggregate_solutions, winning_solutions
+        )
 
-                        token_pair_surplus_alt = aggregate_solution_alt[token_pair]
-                        token_pair_objective_alt = Fraction(
-                            Fraction(solution_alt["objective"]["total"]), 10**18
-                        )
+        total_combinatorial_surplus = sum(
+            sum(surplus for _, surplus in token_pair_surplus.items())
+            for _, token_pair_surplus in winning_solvers.items()
+        )
+        total_surplus = sum(surplus for _, surplus in aggregate_solution.items())
 
-                        a_abs_eth = (
-                            min(token_pair_surplus_alt, token_pair_objective_alt)
-                            - token_pair_surplus
-                        )
-                        a_rel = a_abs_eth / token_pair_surplus
+        a_abs_eth = total_combinatorial_surplus - total_surplus
 
-                        log_output = "\t".join(
-                            [
-                                "Combinatorial auction surplus test:",
-                                f"Tx Hash: {competition_data['transactionHash']}",
-                                f"Token pair: {token_pair}",
-                                f"Winning Solver: {solution['solver']}",
-                                f"Solver providing more surplus: {solution_alt['solver']}",
-                                f"Relative deviation: {float(a_rel * 100):.4f}%",
-                                f"Absolute difference: {float(a_abs_eth):.5f}ETH",
-                            ]
-                        )
-
-                        if (
-                            a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH
-                            and a_rel > SURPLUS_REL_DEVIATION
-                        ):
-                            self.alert(log_output)
-                        elif (
-                            a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH / 10
-                            and a_rel > SURPLUS_REL_DEVIATION / 10
-                        ):
-                            self.logger.info(log_output)
-                        else:
-                            self.logger.debug(log_output)
+        log_output = "\t".join(
+            [
+                "Combinatorial auction surplus test:",
+                f"Tx Hash: {competition_data['transactionHash']}",
+                f"Winning Solver: {solution['solver']}",
+                f"Combinatorial winners: {winning_solvers}",
+                f"Total surplus: {float(total_surplus):.5f} ETH",
+                f"Combinatorial surplus: {float(total_combinatorial_surplus):.5f} ETH",
+                f"Absolute difference: {float(a_abs_eth):.5f}ETH",
+            ]
+        )
+        if a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH:
+            self.alert(log_output)
+        elif a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH / 10 or not filter_mask[-1]:
+            self.logger.info(log_output)
+        else:
+            self.logger.debug(log_output)
 
         return True
 
@@ -98,29 +107,124 @@ class CombinatorialAuctionSurplusTest(BaseTest):
         self, solution: dict[str, Any], prices: dict[str, float]
     ) -> dict[tuple[str, str], Fraction]:
         """Aggregate surplus of a solution on the different token pairs.
-        The result is a dict containing token pairs and the aggregated surplus on them.
+        The result is a dict containing directed token pairs and the aggregated surplus on them.
+
+        Instead of surplus we use the minimum of surplus and the objective. This is more
+        conservative than just using objective. If fees are larger than costs, the objective is
+        larger than surplus and surplus is used for the comparison. If fees are larger than costs,
+        the objective is smaller than surplus and the objective is used instead of surplus for
+        filtering. This takes care of the case of solvers providing a lot of surplus but at really
+        large costs.
         """
         trades_dict = self.get_uid_trades(solution)
+        objective = solution["objective"]["total"]
         surplus_dict: dict[tuple[str, str], Fraction] = {}
         for uid in trades_dict:
             trade = trades_dict[uid]
             token_pair = (trade.data.sell_token.lower(), trade.data.buy_token.lower())
 
+            # compute the conversion rate of the surplus token to ETH
             if trade.get_surplus_token() == trade.data.sell_token:
-                token_to_eth = Fraction(
+                surplus_token_to_eth = Fraction(
                     int(prices[token_pair[0]]),
                     10**36,
                 )
             elif trade.get_surplus_token() == trade.data.buy_token:
-                token_to_eth = Fraction(
+                surplus_token_to_eth = Fraction(
                     int(prices[token_pair[1]]),
                     10**36,
                 )
-            surplus_dict[token_pair] = (
-                surplus_dict.get(token_pair, 0) + token_to_eth * trade.get_surplus()
-            )
+
+            # use the minimum of surplus and objective
+            surplus = min(surplus_token_to_eth * trade.get_surplus(), objective)
+
+            surplus_dict[token_pair] = surplus_dict.get(token_pair, 0) + surplus
 
         return surplus_dict
+
+    def compute_baseline_surplus(
+        self, aggregated_solutions: list[dict[tuple[str, str], Fraction]]
+    ) -> dict[tuple[str, str], tuple[Fraction, int]]:
+        """Computes baseline surplus for all token pairs.
+        The baseline is computed from those solutions which only contain orders for a single token
+        pair.
+        The result is a dict containing directed token pairs and the aggregated surplus on them as
+        well as the index of the corresponding solution in the solutions list.
+        """
+        result: dict[tuple[str, str], tuple[Fraction, int]] = {}
+        for i, aggregate_solution in enumerate(aggregated_solutions):
+            if len(aggregate_solution) == 1:
+                token_pair, surplus = list(aggregate_solution.items())[0]
+                surplus_old = result.get(token_pair, (0, -1))[0]
+                if surplus > surplus_old:
+                    result[token_pair] = (surplus, i)
+        return result
+
+    def filter_solutions(
+        self,
+        aggregate_solutions: list[dict[tuple[str, str], Fraction]],
+        baseline_surplus: dict[tuple[str, str], tuple[Fraction, int]],
+    ) -> list[bool]:
+        """Filter out solutions which do not provide enough surplus.
+        Only solutions are considered for ranking that supply more surplus than any of the single
+        aggregate order solutions. The function returns a list of bools where False means the
+        solution is filtered out.
+        """
+        result = [True for solution in aggregate_solutions]
+        for i, aggregate_solution in enumerate(aggregate_solutions):
+            flag = True
+            for token_pair, surplus in aggregate_solution.items():
+                surplus_ref = baseline_surplus.get(token_pair, (0, ""))[0]
+                if surplus < surplus_ref:
+                    flag = False
+            result[i] = flag
+
+        return result
+
+    def determine_winning_solutions(
+        self,
+        aggregate_solutions: list[dict[tuple[str, str], Fraction]],
+        baseline_surplus: dict[tuple[str, str], tuple[Fraction, int]],
+        filter_mask: list[bool],
+    ) -> dict[tuple[str, str], int]:
+        """Determine the winning solutions for the different token pairs.
+        There is one batch winner, and the remaining token pairs are won by single aggregate order
+        solutions.
+        """
+        result: dict[tuple[str, str], int] = {}
+        # one batch winner
+        for i, _ in reversed(list(enumerate(aggregate_solutions))):
+            if filter_mask[i]:
+                batch_winner_index = i
+                break
+        for token_pair, _ in aggregate_solutions[batch_winner_index].items():
+            result[token_pair] = batch_winner_index
+        # the remaining token pairs are won by baseline solutions
+        for token_pair, surplus_and_index in baseline_surplus.items():
+            if not token_pair in result:
+                result[token_pair] = surplus_and_index[1]
+        return result
+
+    def determine_winning_solvers(
+        self,
+        solutions: list[dict[str, Any]],
+        aggregated_solutions: list[dict[tuple[str, str], Fraction]],
+        winning_solutions: dict[tuple[str, str], int],
+    ) -> dict[str, dict[tuple[str, str], Fraction]]:
+        """Determine the winning solvers and the surplus for each token pair.
+        There is one batch winner, and the remaining token pairs are won by single aggregate order
+        solutions.
+        """
+        result: dict[str, dict[tuple[str, str], Fraction]] = {}
+        for token_pair, solution_index in winning_solutions.items():
+            solution = solutions[solution_index]
+            solver = solution["solver"]
+            if not solver in result:
+                result[solver] = {}
+            result[solver][token_pair] = aggregated_solutions[solution_index][
+                token_pair
+            ]
+        return result
 
     def run(self, tx_hash: str) -> bool:
         """

--- a/src/monitoring_tests/combinatorial_auction_surplus_test.py
+++ b/src/monitoring_tests/combinatorial_auction_surplus_test.py
@@ -2,7 +2,6 @@
 Comparing order surplus per token pair to a reference solver in the competition.
 """
 # pylint: disable=logging-fstring-interpolation
-# pylint: disable=duplicate-code
 
 from typing import Any
 from fractions import Fraction
@@ -39,6 +38,7 @@ class CombinatorialAuctionSurplusTest(BaseTest):
         self.orderbook_api = OrderbookAPI()
 
     def run_combinatorial_auction(self, competition_data: dict[str, Any]) -> bool:
+        # pylint: disable=too-many-locals
         """Run combinatorial auction on competition data.
 
         The combinatorial auction consists of 4 steps:

--- a/src/monitoring_tests/combinatorial_auction_surplus_test.py
+++ b/src/monitoring_tests/combinatorial_auction_surplus_test.py
@@ -101,7 +101,7 @@ class CombinatorialAuctionSurplusTest(BaseTest):
                 f"Absolute difference: {float(a_abs_eth):.5f}ETH",
             ]
         )
-        if a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH:
+        if "BaselineSolver" in solutions_filtering_winner:
             self.alert(log_output)
         elif (
             a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH / 10

--- a/src/monitoring_tests/combinatorial_auction_surplus_test.py
+++ b/src/monitoring_tests/combinatorial_auction_surplus_test.py
@@ -274,10 +274,11 @@ class CombinatorialAuctionSurplusTest(BaseTest):
             result[solver][token_pair] = aggregate_solutions[solution_index][token_pair]
         return result
 
-    def run(self, tx_hash: str) -> bool:
         """
+    def run(self, tx_hash: str) -> bool:
+        """Runs the combinatoral auction surplus test
         Wrapper function for the whole test. Checks if solver competition data is retrievable
-        and runs EBBO test, else returns True to add to list of unchecked hashes.
+        and runs the test, else returns False to add to list of unchecked hashes.
         """
 
         solver_competition_data = self.orderbook_api.get_solver_competition_data(

--- a/src/monitoring_tests/combinatorial_auction_surplus_test.py
+++ b/src/monitoring_tests/combinatorial_auction_surplus_test.py
@@ -86,16 +86,33 @@ class CombinatorialAuctionSurplusTest(BaseTest):
 
         a_abs_eth = total_combinatorial_surplus - total_surplus
 
+        # convert surplus to float for logging
+        winning_aggregate_surplus_float = {
+            token_pair: float(surplus)
+            for token_pair, surplus in winning_aggregate_solution.items()
+        }
+        baseline_surplus_float = {
+            token_pair: (float(surplus_index[0]), surplus_index[1])
+            for token_pair, surplus_index in baseline_surplus.items()
+        }
+        winning_solvers_float = {
+            solver_name: {
+                token_pair: float(surplus)
+                for token_pair, surplus in aggregate_solution.items()
+            }
+            for solver_name, aggregate_solution in winning_solvers.items()
+        }
+
         log_output = "\t".join(
             [
                 "Combinatorial auction surplus test:",
                 f"Tx Hash: {competition_data['transactionHash']}",
                 f"Winning Solver: {winning_solution['solver']}",
-                f"Winning surplus: {aggregate_solution}",
-                f"Baseline surplus: {baseline_surplus}",
+                f"Winning surplus: {winning_aggregate_surplus_float}",
+                f"Baseline surplus: {baseline_surplus_float}",
                 f"Solutions filtering winner: {filter_mask[-1]}",
                 f"Solvers filtering winner: {solutions_filtering_winner}",
-                f"Combinatorial winners: {winning_solvers}",
+                f"Combinatorial winners: {winning_solvers_float}",
                 f"Total surplus: {float(total_surplus):.5f} ETH",
                 f"Combinatorial surplus: {float(total_combinatorial_surplus):.5f} ETH",
                 f"Absolute difference: {float(a_abs_eth):.5f}ETH",

--- a/src/monitoring_tests/combinatorial_auction_surplus_test.py
+++ b/src/monitoring_tests/combinatorial_auction_surplus_test.py
@@ -2,6 +2,7 @@
 Comparing order surplus per token pair to a reference solver in the competition.
 """
 # pylint: disable=logging-fstring-interpolation
+# pylint: disable=duplicate-code
 
 from typing import Any
 from fractions import Fraction

--- a/src/monitoring_tests/combinatorial_auction_surplus_test.py
+++ b/src/monitoring_tests/combinatorial_auction_surplus_test.py
@@ -1,0 +1,139 @@
+"""
+Comparing order surplus per token pair to a reference solver in the competition.
+"""
+# pylint: disable=logging-fstring-interpolation
+# pylint: disable=duplicate-code
+
+from typing import Any
+from fractions import Fraction
+from src.monitoring_tests.base_test import BaseTest
+from src.apis.web3api import Web3API
+from src.apis.orderbookapi import OrderbookAPI
+from src.models import Trade
+from src.constants import SURPLUS_ABSOLUTE_DEVIATION_ETH, SURPLUS_REL_DEVIATION
+
+
+class CombinatorialAuctionSurplusTest(BaseTest):
+    """
+    This test compares the surplus all orders from the winning settlement to
+    the different executions of these orders by other solvers in the competition.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.web3_api = Web3API()
+        self.orderbook_api = OrderbookAPI()
+
+    def compare_token_pairs_surplus(self, competition_data: dict[str, Any]) -> bool:
+        """
+        This function goes through each token pair that the winning solution executed
+        and finds non-winning solutions that executed the only orders on the same token pair.
+        It then calculates surplus difference between the winning and non-winning solution.
+        """
+
+        aggregate_solutions = [
+            self.get_token_pairs_surplus(
+                solution, competition_data["auction"]["prices"]
+            )
+            for solution in competition_data["solutions"]
+        ]
+        aggregate_solution = aggregate_solutions[-1]
+
+        for token_pair, token_pair_surplus in aggregate_solution.items():
+            for i, aggregate_solution_alt in enumerate(aggregate_solutions[0:-1]):
+                if len(aggregate_solution_alt) == 1:
+                    if token_pair in aggregate_solution_alt:
+                        solution = competition_data["solutions"][-1]
+                        solution_alt = competition_data["solutions"][i]
+
+                        token_pair_surplus_alt = aggregate_solution_alt[token_pair]
+                        token_pair_objective_alt = Fraction(
+                            Fraction(solution_alt["objective"]["total"]), 10**18
+                        )
+
+                        a_abs_eth = (
+                            min(token_pair_surplus_alt, token_pair_objective_alt)
+                            - token_pair_surplus
+                        )
+                        a_rel = a_abs_eth / token_pair_surplus
+
+                        log_output = "\t".join(
+                            [
+                                "Combinatorial auction surplus test:",
+                                f"Tx Hash: {competition_data['transactionHash']}",
+                                f"Token pair: {token_pair}",
+                                f"Winning Solver: {solution['solver']}",
+                                f"Solver providing more surplus: {solution_alt['solver']}",
+                                f"Relative deviation: {float(a_rel * 100):.4f}%",
+                                f"Absolute difference: {float(a_abs_eth):.5f}ETH",
+                            ]
+                        )
+
+                        if (
+                            a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH
+                            and a_rel > SURPLUS_REL_DEVIATION
+                        ):
+                            self.alert(log_output)
+                        elif (
+                            a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH / 10
+                            and a_rel > SURPLUS_REL_DEVIATION / 10
+                        ):
+                            self.logger.info(log_output)
+                        else:
+                            self.logger.debug(log_output)
+
+        return True
+
+    def get_uid_trades(self, solution: dict[str, Any]) -> dict[str, Trade]:
+        """Get a dictionary mapping UIDs to trades in a solution."""
+        calldata = solution["callData"]
+        settlement = self.web3_api.get_settlement_from_calldata(calldata)
+        trades = self.web3_api.get_trades(settlement)
+        trades_dict = {
+            solution["orders"][i]["id"]: trade for (i, trade) in enumerate(trades)
+        }
+        return trades_dict
+
+    def get_token_pairs_surplus(
+        self, solution: dict[str, Any], prices: dict[str, float]
+    ) -> dict[tuple[str, str], Fraction]:
+        """Aggregate surplus of a solution on the different token pairs.
+        The result is a dict containing token pairs and the aggregated surplus on them.
+        """
+        trades_dict = self.get_uid_trades(solution)
+        surplus_dict: dict[tuple[str, str], Fraction] = {}
+        for uid in trades_dict:
+            trade = trades_dict[uid]
+            token_pair = (trade.data.sell_token.lower(), trade.data.buy_token.lower())
+
+            if trade.get_surplus_token() == trade.data.sell_token:
+                token_to_eth = Fraction(
+                    int(prices[token_pair[0]]),
+                    10**36,
+                )
+            elif trade.get_surplus_token() == trade.data.buy_token:
+                token_to_eth = Fraction(
+                    int(prices[token_pair[1]]),
+                    10**36,
+                )
+            surplus_dict[token_pair] = (
+                surplus_dict.get(token_pair, 0) + token_to_eth * trade.get_surplus()
+            )
+
+        return surplus_dict
+
+    def run(self, tx_hash: str) -> bool:
+        """
+        Wrapper function for the whole test. Checks if solver competition data is retrievable
+        and runs EBBO test, else returns True to add to list of unchecked hashes.
+        """
+
+        solver_competition_data = self.orderbook_api.get_solver_competition_data(
+            tx_hash
+        )
+        if solver_competition_data is None:
+            return False
+
+        success = self.compare_token_pairs_surplus(solver_competition_data)
+
+        return success

--- a/src/monitoring_tests/combinatorial_auction_surplus_test.py
+++ b/src/monitoring_tests/combinatorial_auction_surplus_test.py
@@ -38,11 +38,16 @@ class CombinatorialAuctionSurplusTest(BaseTest):
         self.web3_api = Web3API()
         self.orderbook_api = OrderbookAPI()
 
-    def compare_token_pairs_surplus(self, competition_data: dict[str, Any]) -> bool:
-        """
-        This function goes through each token pair that the winning solution executed
-        and finds non-winning solutions that executed the only orders on the same token pair.
-        It then calculates surplus difference between the winning and non-winning solution.
+    def run_combinatorial_auction(self, competition_data: dict[str, Any]) -> bool:
+        """Run combinatorial auction on competition data.
+
+        The combinatorial auction consists of 4 steps:
+        1. Aggregate surplus on the different directed sell token-buy token pairs for all solutions
+           in the competition.
+        2. Compute a baseline for surplus on all token pairs from those solutions.
+        3. Filter solutions which to not provide at least as much surplus as the baseline on all
+           token pairs.
+        4. Choose one batch winner and multiple single order winners.
         """
 
         solutions = competition_data["solutions"]
@@ -238,6 +243,6 @@ class CombinatorialAuctionSurplusTest(BaseTest):
         if solver_competition_data is None:
             return False
 
-        success = self.compare_token_pairs_surplus(solver_competition_data)
+        success = self.run_combinatorial_auction(solver_competition_data)
 
         return success

--- a/tests/e2e/combinatorial_auction_surplus_test.py
+++ b/tests/e2e/combinatorial_auction_surplus_test.py
@@ -23,7 +23,9 @@ class TestCombinatorialAuctionSurplus(unittest.TestCase):
         # # combinatorial auction better than current auction
         # tx_hash = "0x46639ae0e516bcad7b052fb6bfb6227d0aa2707e9882dd8d86bab2ab6aeee155"
         # tx_hash = "0xe28b92ba73632d6b167fdb9bbfec10744ce208536901dd43379a6778c4408536"
-        tx_hash = "0xad0ede9fd68481b8ef4722d069598898e01d61427ccb378ca4c82c772c6644e0"
+        # tx_hash = "0xad0ede9fd68481b8ef4722d069598898e01d61427ccb378ca4c82c772c6644e0"
+        # tx_hash = "0xead8f01e8e24fdc306fca8fcac5146edc22c27e49a7aad6134adc2ad50ba8581"
+        tx_hash = "0x6200e744e5d6f9990271be53840c01044cc19f3a8526190e1eaac0bc5fefed85"
         self.assertTrue(surplus_test.run(tx_hash))
 
 

--- a/tests/e2e/combinatorial_auction_surplus_test.py
+++ b/tests/e2e/combinatorial_auction_surplus_test.py
@@ -1,0 +1,22 @@
+"""
+Tests for combinatorial auction surplus test.
+"""
+
+import unittest
+from src.monitoring_tests.combinatorial_auction_surplus_test import (
+    CombinatorialAuctionSurplusTest,
+)
+
+
+class TestCombinatorialAuctionSurplus(unittest.TestCase):
+    def test_surplus(self) -> None:
+        surplus_test = CombinatorialAuctionSurplusTest()
+        # Baseline EBBO error
+        # tx_hash = "0x4115f6f4abaea17f2ebef3a1e75c589c38cac048ff5116d406038e48ff7aeacd"
+        # large settlement with bad execution for one of the orders
+        tx_hash = "0xc22b1e4984b212e679d4af49c1622e7018c83d5e32ece590cf84a3e1950f9f18"
+        self.assertTrue(surplus_test.run(tx_hash))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/combinatorial_auction_surplus_test.py
+++ b/tests/e2e/combinatorial_auction_surplus_test.py
@@ -11,10 +11,19 @@ from src.monitoring_tests.combinatorial_auction_surplus_test import (
 class TestCombinatorialAuctionSurplus(unittest.TestCase):
     def test_surplus(self) -> None:
         surplus_test = CombinatorialAuctionSurplusTest()
-        # Baseline EBBO error
+        # # Baseline EBBO error
         # tx_hash = "0x4115f6f4abaea17f2ebef3a1e75c589c38cac048ff5116d406038e48ff7aeacd"
-        # large settlement with bad execution for one of the orders
-        tx_hash = "0xc22b1e4984b212e679d4af49c1622e7018c83d5e32ece590cf84a3e1950f9f18"
+        # # large settlement with bad execution for one of the orders
+        # tx_hash = "0xc22b1e4984b212e679d4af49c1622e7018c83d5e32ece590cf84a3e1950f9f18"
+        # # EBBO violations
+        # #
+        # tx_hash = "0x2ff69424f7bf8951ed5e7dd04b648380b0e73dbf7f0191c800651bc4b16a30c5"
+        # # combinatorial auction worse than current auction
+        # tx_hash = "0xb743b023ad838f04680fd321bf579c35931c4f886f664bd2b6e675c310a9c287"
+        # # combinatorial auction better than current auction
+        # tx_hash = "0x46639ae0e516bcad7b052fb6bfb6227d0aa2707e9882dd8d86bab2ab6aeee155"
+        # tx_hash = "0xe28b92ba73632d6b167fdb9bbfec10744ce208536901dd43379a6778c4408536"
+        tx_hash = "0xad0ede9fd68481b8ef4722d069598898e01d61427ccb378ca4c82c772c6644e0"
         self.assertTrue(surplus_test.run(tx_hash))
 
 


### PR DESCRIPTION
We are thinking about implementing combinatorial auctions. This would include filtering out solutions which do not provide more surplus on individual sell token-buy token pairs compared to solutions only including that token pair.

The test in this PR checks if the winning solution would have been filtered out based on this criterion.

One difference to the competition surplus test is that the test in this PR checks token pairs and not orders.

Potentially we want to check more in this test. E.g.
- Who would have won the auction with the filtering rule?
- Who would have won the auction with the option to declare multiple winners?
- What would the benefit in surplus have been?

Todo
- [ ] Fix relative test to compare price improvement and not surplus improvement.