### PR TITLE
Add tenderly api to simulate solutions

### DIFF
--- a/src/apis/tenderlyapi.py
+++ b/src/apis/tenderlyapi.py
@@ -1,0 +1,95 @@
+"""
+TenderlyAPI for simulating transactions on tenderly.
+"""
+# pylint: disable=logging-fstring-interpolation
+
+from os import getenv
+from typing import Any, Optional
+import requests
+from dotenv import load_dotenv
+from src.helper_functions import get_logger
+from src.constants import (
+    SETTLEMENT_CONTRACT_ADDRESS,
+    REQUEST_TIMEOUT,
+)
+
+
+class TenderlyAPI:
+    """
+    Class for simulating transactions on tenderly.
+    """
+
+    def __init__(self) -> None:
+        self.logger = get_logger()
+        load_dotenv()
+        self.tenderly_url = (
+            "https://api.tenderly.co/api/v1/account/"
+            + str(getenv("TENDERLY_USER"))
+            + "/project/"
+            + str(getenv("TENDERLY_PROJECT"))
+            + "/simulate"
+        )
+
+    def simulate_solution(
+        self, solution: dict[str, Any], block_number: int, internalize: bool = True
+    ) -> Optional[dict[str, Any]]:
+        """Simulate a solution from the solver competition at a specified block number.
+        The solution dictionary follows the convention from the competition endpoint.
+        If internalize == False, uninternalized calldata is used for the simulation if it exists.
+        """
+        if not internalize and "uninternalizedCallData" in solution:
+            calldata = solution["uninternalizedCallData"]
+        else:
+            calldata = solution["callData"]
+
+        return self.simulate_transaction(
+            calldata, solution["solverAddress"], block_number
+        )
+
+    def simulate_transaction(
+        self, calldata: str, solver: str, block_number: int
+    ) -> Optional[dict[str, Any]]:
+        """Simulate a transaction from solver with given calldata at a specified block number."""
+
+        simulation_output: Optional[dict[str, Any]] = None
+        try:
+            simulation_input = {
+                "save": True,  # if true simulation is saved and shows up in the dashboard
+                "save_if_fails": True,  # if true, reverting simulations show up in the dashboard
+                "simulation_type": "quick",  # full or quick (full is default)
+                # network to simulate on
+                "network_id": "1",
+                # simulate transaction at this (historical) block number
+                "block_number": block_number,
+                # simulate transaction at this index within the (historical) block
+                # "transaction_index": 0,
+                # Standard EVM Transaction object
+                "from": solver,
+                "input": calldata,
+                "to": SETTLEMENT_CONTRACT_ADDRESS,
+                # "gas": 138864,
+                # "gas_price": "32909736476",
+                "value": "0",
+                # "access_list": [],
+                # "generate_access_list": True,
+            }
+
+            json_simulation_output = requests.post(
+                self.tenderly_url,
+                headers={
+                    "X-Access-Key": str(getenv("TENDERLY_ACCESS_KEY")),
+                },
+                timeout=REQUEST_TIMEOUT,
+                json=simulation_input,
+            )
+            if json_simulation_output.ok:
+                simulation_output = json_simulation_output.json()
+            else:
+                return None
+        except requests.RequestException as err:
+            self.logger.warning(
+                f"Error while simulating transaction.\
+                    Simulation input: {simulation_input}, error: {err}"
+            )
+            return None
+        return simulation_output

--- a/src/apis/tenderlyapi.py
+++ b/src/apis/tenderlyapi.py
@@ -42,11 +42,9 @@ class TenderlyAPI:
         else:
             calldata = solution["callData"]
 
-        return self.simulate_transaction(
-            calldata, solution["solverAddress"], block_number
-        )
+        return self.simulate_calldata(calldata, solution["solverAddress"], block_number)
 
-    def simulate_transaction(
+    def simulate_calldata(
         self, calldata: str, solver: str, block_number: int
     ) -> Optional[dict[str, Any]]:
         """Simulate a transaction from solver with given calldata at a specified block number."""


### PR DESCRIPTION
Adds an API for calling tenderly to simulate solutions from the competition endpoint.

It requires to set the environment variables `TENDERLY_USER`, `TENDERLY_PROJECT`, and `TENDERLY_ACCESS_KEY`.

Example usage is
```python
from src.apis.orderbookapi import OrderbookAPI
from src.apis.tenderlyapi import TenderlyAPI
orderbook_api = OrderbookAPI()
tenderly_api = TenderlyAPI()

tx_hash = "0xfabafaf60c538d22956e5ffe67512ba9ea29f0843fa80e2a1e1a7bc2ec8a96e9"
competition_data = orderbook_api.get_solver_competition_data(tx_hash)

solution = competition_data["solutions"][-1]
block_number = competition_data["competitionSimulationBlock"]
internalize = False
simulation_result = tenderly_api.simulate_solution(solution, block_number, internalize)
```