### PR TITLE
fix minor issue in get_filtered_receipts

### DIFF
--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -51,6 +51,8 @@ class Web3API:
         """
         Function filters receipts by contract address, and block ranges
         """
+        if start_block > end_block:
+            return []
         filter_criteria: FilterParams = {
             "fromBlock": int(start_block),
             "toBlock": int(end_block),


### PR DESCRIPTION
This minor PR attempts to fix [this](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-90d%2Fd,to:now))&_a=(columns:!(log),filters:!(),index:ea511870-d9b3-11ed-a9d0-a17451f01cc1,interval:auto,query:(language:kuery,query:'%22invalid%20from%20and%20to%20block%20combination%22'),sort:!(!('@timestamp',desc)))) exception, that is happening from time to time.