### PR TITLE
Fix scaling of objective in combinatorial auction test

### DIFF
--- a/src/monitoring_tests/combinatorial_auction_surplus_test.py
+++ b/src/monitoring_tests/combinatorial_auction_surplus_test.py
@@ -163,7 +163,8 @@ class CombinatorialAuctionSurplusTest(BaseTest):
         if len(surplus_dict) == 1:
             for token_pair in surplus_dict:
                 surplus_dict[token_pair] = min(
-                    surplus_dict[token_pair], solution["objective"]["total"]
+                    surplus_dict[token_pair],
+                    Fraction(solution["objective"]["total"]) / 10**18,
                 )
 
         return surplus_dict

--- a/tests/e2e/combinatorial_auction_surplus_test.py
+++ b/tests/e2e/combinatorial_auction_surplus_test.py
@@ -25,7 +25,9 @@ class TestCombinatorialAuctionSurplus(unittest.TestCase):
         # tx_hash = "0xe28b92ba73632d6b167fdb9bbfec10744ce208536901dd43379a6778c4408536"
         # tx_hash = "0xad0ede9fd68481b8ef4722d069598898e01d61427ccb378ca4c82c772c6644e0"
         # tx_hash = "0xead8f01e8e24fdc306fca8fcac5146edc22c27e49a7aad6134adc2ad50ba8581"
-        tx_hash = "0x6200e744e5d6f9990271be53840c01044cc19f3a8526190e1eaac0bc5fefed85"
+        # tx_hash = "0x6200e744e5d6f9990271be53840c01044cc19f3a8526190e1eaac0bc5fefed85"
+        # uncovered bug with wrong scaling of objective
+        tx_hash = "0x97b2f8402d239e16b62b7cc2302ed77ac8fa40d63114ab6804041c9d3b9e6b81"
         self.assertTrue(surplus_test.run(tx_hash))
 
 


### PR DESCRIPTION
Objective in competition data is in wei, the rest of the test works with
ETH. With this fix, the objective is now correctly scaled to ETH as well.