### PR TITLE
[CIP-38] Add Uniform Directional Clearing Prices test

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -31,6 +31,9 @@ BUFFERS_VALUE_USD_THRESHOLD = 200000
 # threshold parameter to generate an alert when receiving kickbacks
 KICKBACKS_ALERT_THRESHOLD = 0.1
 
+# threshold to generate an alert for violating UDP
+UDP_SENSITIVITY_THRESHOLD = 0.005
+
 # relevant addresses
 SETTLEMENT_CONTRACT_ADDRESS = "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"
 MEV_BLOCKER_KICKBACKS_ADDRESS = "0xCe91228789B57DEb45e66Ca10Ff648385fE7093b"

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -27,6 +27,9 @@ from src.monitoring_tests.combinatorial_auction_surplus_test import (
 from src.monitoring_tests.cost_coverage_zero_signed_fee import (
     CostCoverageForZeroSignedFee,
 )
+from src.monitoring_tests.uniform_directed_prices_test import (
+    UniformDirectedPricesTest,
+)
 from src.constants import SLEEP_TIME_IN_SEC
 
 
@@ -44,6 +47,7 @@ def main() -> None:
         BuffersMonitoringTest(),
         CombinatorialAuctionSurplusTest(),
         CostCoverageForZeroSignedFee(),
+        UniformDirectedPricesTest(),
     ]
 
     start_block: Optional[int] = None

--- a/src/monitoring_tests/uniform_directed_prices_test.py
+++ b/src/monitoring_tests/uniform_directed_prices_test.py
@@ -1,0 +1,77 @@
+"""
+Checks the uniform directed prices constraint that was introduced with CIP-38
+"""
+# pylint: disable=logging-fstring-interpolation
+from typing import Any
+from src.monitoring_tests.base_test import BaseTest
+from src.apis.orderbookapi import OrderbookAPI
+from src.constants import (
+    UDP_SENSITIVITY_THRESHOLD,
+)
+
+
+class UniformDirectedPricesTest(BaseTest):
+    """
+    This test checks whether the Uniform Directed Prices constraint,
+    as introduced in CIP-38, is satisfied.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.orderbook_api = OrderbookAPI()
+
+    def check_udp(self, competition_data: dict[str, Any]) -> bool:
+        """
+        This function checks whether there are multiple orders in the same directed token pair,
+        and if so, checks wheter UDP is satisfied.
+        """
+        solution = competition_data["solutions"][-1]
+        trades_dict = self.orderbook_api.get_uid_trades(solution)
+        if trades_dict is None:
+            return False
+        token_pairs = {}
+        for uid in trades_dict:
+            trade = trades_dict[uid]
+            sell_token = trade.data.sell_token
+            buy_token = trade.data.buy_token
+            sell_amount = trade.execution.sell_amount
+            buy_amount = trade.execution.buy_amount
+            if (sell_token, buy_token) not in token_pairs:
+                token_pairs[(sell_token, buy_token)] = [sell_amount / buy_amount]
+            else:
+                token_pairs[(sell_token, buy_token)].append(sell_amount / buy_amount)
+        for tp in token_pairs:
+            if len(token_pairs[tp]) == 1:
+                continue
+            rate = token_pairs[tp][0]
+            for r in token_pairs[tp]:
+                if r < rate:
+                    rate = r
+            lower_r = rate * (1 - UDP_SENSITIVITY_THRESHOLD)
+            upper_r = rate * (1 + UDP_SENSITIVITY_THRESHOLD)
+            for r in token_pairs[tp]:
+                if r < lower_r or r > upper_r:
+                    log_output = "\t".join(
+                        [
+                            "Uniform Directed Prices test:",
+                            f"Tx Hash: {competition_data['transactionHash']}",
+                            f"Token pair: {tp}",
+                        ]
+                    )
+                    self.alert(log_output)
+        return True
+
+    def run(self, tx_hash: str) -> bool:
+        """
+        Wrapper function for the whole test. Checks if violation is more than
+        UDP_SENSITIVITY_THRESHOLD, in which case it generates an alert.
+        """
+        solver_competition_data = self.orderbook_api.get_solver_competition_data(
+            tx_hash
+        )
+        if solver_competition_data is None:
+            return False
+
+        success = self.check_udp(solver_competition_data)
+
+        return success


### PR DESCRIPTION
This PR adds a check for the UDP rule, as introduced in [CIP-38](https://snapshot.org/#/cow.eth/proposal/0xfb81daea9be89f4f1c251d53fd9d1481129b97c6f38caaddc42af7f3ce5a52ec).