### PR TITLE
Remove alerts for cost coverage

### DIFF
--- a/src/monitoring_tests/cost_coverage_zero_signed_fee.py
+++ b/src/monitoring_tests/cost_coverage_zero_signed_fee.py
@@ -13,8 +13,7 @@ from src.apis.orderbookapi import OrderbookAPI
 class CostCoverageForZeroSignedFee(BaseTest):
     """
     This test checks the cost coverage of in-market orders that are
-    sent as zero-signed fee orders from CoW Swap.
-    """
+    sent as zero-signed fee orders from CoW Swap.    """
 
     def __init__(self) -> None:
         super().__init__()
@@ -63,19 +62,11 @@ class CostCoverageForZeroSignedFee(BaseTest):
                 / 10**36
             )
             total_fee += fee
-        if total_fee - gas_cost > 0.002 or total_fee - gas_cost < -0.002:
-            if zero_signed_fee_market and (
-                total_fee - gas_cost > 0.02 or total_fee - gas_cost < -0.01
-            ):
-                self.alert(
-                    f'"Fees - gasCost" is {total_fee - gas_cost} \
-                        for {competition_data["transactionHash"]}.'
-                )
-            else:
-                self.logger.info(
-                    f'"Fees - gasCost" is {total_fee - gas_cost} \
-                    for {competition_data["transactionHash"]}.'
-                )
+        if total_fee - gas_cost > 0.02 or total_fee - gas_cost < -0.04:
+            self.logger.info(
+                f'"Fees - gasCost" is {total_fee - gas_cost} \
+                for {competition_data["transactionHash"]}.'
+            )
         return True
 
     def run(self, tx_hash: str) -> bool:


### PR DESCRIPTION
This PR removes all alerts for cost coverage, and only logs the relevant cases; the rationale being that with CIP-38, the protocol shouldn't in principle worry about cost coverage. This dune query can help with monitoring whenever needed.
https://dune.com/queries/3431685