### PR TITLE
Add new urls for auction instances

### DIFF
--- a/src/apis/auctioninstanceapi.py
+++ b/src/apis/auctioninstanceapi.py
@@ -16,8 +16,12 @@ from src.constants import (
     FAIL_CODE,
 )
 
-PROD_BASE_URL = "https://solver-instances.s3.eu-central-1.amazonaws.com/prod-mainnet/"
-BARN_BASE_URL = "https://solver-instances.s3.eu-central-1.amazonaws.com/barn-mainnet/"
+PROD_BASE_URL = (
+    "https://solver-instances.s3.eu-central-1.amazonaws.com/prod/mainnet/legacy/"
+)
+BARN_BASE_URL = (
+    "https://solver-instances.s3.eu-central-1.amazonaws.com/barn/mainnet/legacy/"
+)
 
 
 class AuctionInstanceAPI:


### PR DESCRIPTION
Update urls for auction instances. The old url made all tests with the reference solver fail automatically.

This closes #100.