### PR TITLE
Fix name of baseline solver in combinatorial auction test

### DIFF
--- a/src/monitoring_tests/combinatorial_auction_surplus_test.py
+++ b/src/monitoring_tests/combinatorial_auction_surplus_test.py
@@ -96,7 +96,7 @@ class CombinatorialAuctionSurplusTest(BaseTest):
                 f"Absolute difference: {float(a_abs_eth):.5f}ETH",
             ]
         )
-        if "BaselineSolver" in solutions_filtering_winner:
+        if "baseline" in solutions_filtering_winner:
             self.alert(log_output)
         elif (
             a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH / 10


### PR DESCRIPTION
The combinatorial auction test did never create an alert because the name of the baseline solver was written incorrectly. The name is fixed now, from `BaselineSolver` to `baseline`. The latter is the name used in the solver competition endpoint since colocation.