### PR TITLE
Increase MEV Blocker kickback threshold

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -29,7 +29,7 @@ BUFFER_INTERVAL = 150
 BUFFERS_VALUE_USD_THRESHOLD = 200000
 
 # threshold parameter to generate an alert when receiving kickbacks
-KICKBACKS_ALERT_THRESHOLD = 0.1
+KICKBACKS_ALERT_THRESHOLD = 0.5
 
 # threshold to generate an alert for violating UDP
 UDP_SENSITIVITY_THRESHOLD = 0.005


### PR DESCRIPTION
This PR changes the threshold for alerst on slack to `0.5 ETH` (up from `0.1 ETH`).

Alerts for the old threshold are quite frequent and are not immediately actionable. They can now be recovered in aggregate from [this dune query](https://dune.com/queries/3668122).