### PR TITLE
Add test for CoW AMM commitment

### DIFF
--- a/contracts/cowamm_constantproduct.py
+++ b/contracts/cowamm_constantproduct.py
@@ -1,0 +1,213 @@
+cowamm_constantproduct = [
+    {
+        "inputs": [
+            {"internalType": "address", "name": "_solutionSettler", "type": "address"}
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor",
+    },
+    {"inputs": [], "name": "CommitOutsideOfSettlement", "type": "error"},
+    {"inputs": [], "name": "OrderDoesNotMatchCommitmentHash", "type": "error"},
+    {"inputs": [], "name": "OrderDoesNotMatchDefaultTradeableOrder", "type": "error"},
+    {
+        "inputs": [{"internalType": "string", "name": "", "type": "string"}],
+        "name": "OrderNotValid",
+        "type": "error",
+    },
+    {
+        "inputs": [
+            {"internalType": "uint256", "name": "blockNumber", "type": "uint256"},
+            {"internalType": "string", "name": "message", "type": "string"},
+        ],
+        "name": "PollTryAtBlock",
+        "type": "error",
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address",
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "contract IConditionalOrder",
+                        "name": "handler",
+                        "type": "address",
+                    },
+                    {"internalType": "bytes32", "name": "salt", "type": "bytes32"},
+                    {"internalType": "bytes", "name": "staticInput", "type": "bytes"},
+                ],
+                "indexed": False,
+                "internalType": "struct IConditionalOrder.ConditionalOrderParams",
+                "name": "params",
+                "type": "tuple",
+            },
+        ],
+        "name": "ConditionalOrderCreated",
+        "type": "event",
+    },
+    {
+        "inputs": [],
+        "name": "EMPTY_COMMITMENT",
+        "outputs": [{"internalType": "bytes32", "name": "", "type": "bytes32"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "MAX_ORDER_DURATION",
+        "outputs": [{"internalType": "uint32", "name": "", "type": "uint32"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "owner", "type": "address"},
+            {"internalType": "bytes32", "name": "orderHash", "type": "bytes32"},
+        ],
+        "name": "commit",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "name": "commitment",
+        "outputs": [{"internalType": "bytes32", "name": "", "type": "bytes32"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "owner", "type": "address"},
+            {"internalType": "address", "name": "", "type": "address"},
+            {"internalType": "bytes32", "name": "", "type": "bytes32"},
+            {"internalType": "bytes", "name": "staticInput", "type": "bytes"},
+            {"internalType": "bytes", "name": "", "type": "bytes"},
+        ],
+        "name": "getTradeableOrder",
+        "outputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "sellToken",
+                        "type": "address",
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "buyToken",
+                        "type": "address",
+                    },
+                    {"internalType": "address", "name": "receiver", "type": "address"},
+                    {
+                        "internalType": "uint256",
+                        "name": "sellAmount",
+                        "type": "uint256",
+                    },
+                    {"internalType": "uint256", "name": "buyAmount", "type": "uint256"},
+                    {"internalType": "uint32", "name": "validTo", "type": "uint32"},
+                    {"internalType": "bytes32", "name": "appData", "type": "bytes32"},
+                    {"internalType": "uint256", "name": "feeAmount", "type": "uint256"},
+                    {"internalType": "bytes32", "name": "kind", "type": "bytes32"},
+                    {
+                        "internalType": "bool",
+                        "name": "partiallyFillable",
+                        "type": "bool",
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "sellTokenBalance",
+                        "type": "bytes32",
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "buyTokenBalance",
+                        "type": "bytes32",
+                    },
+                ],
+                "internalType": "struct GPv2Order.Data",
+                "name": "",
+                "type": "tuple",
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "solutionSettler",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "bytes4", "name": "interfaceId", "type": "bytes4"}],
+        "name": "supportsInterface",
+        "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "owner", "type": "address"},
+            {"internalType": "address", "name": "", "type": "address"},
+            {"internalType": "bytes32", "name": "orderHash", "type": "bytes32"},
+            {"internalType": "bytes32", "name": "", "type": "bytes32"},
+            {"internalType": "bytes32", "name": "", "type": "bytes32"},
+            {"internalType": "bytes", "name": "staticInput", "type": "bytes"},
+            {"internalType": "bytes", "name": "", "type": "bytes"},
+            {
+                "components": [
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "sellToken",
+                        "type": "address",
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "buyToken",
+                        "type": "address",
+                    },
+                    {"internalType": "address", "name": "receiver", "type": "address"},
+                    {
+                        "internalType": "uint256",
+                        "name": "sellAmount",
+                        "type": "uint256",
+                    },
+                    {"internalType": "uint256", "name": "buyAmount", "type": "uint256"},
+                    {"internalType": "uint32", "name": "validTo", "type": "uint32"},
+                    {"internalType": "bytes32", "name": "appData", "type": "bytes32"},
+                    {"internalType": "uint256", "name": "feeAmount", "type": "uint256"},
+                    {"internalType": "bytes32", "name": "kind", "type": "bytes32"},
+                    {
+                        "internalType": "bool",
+                        "name": "partiallyFillable",
+                        "type": "bool",
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "sellTokenBalance",
+                        "type": "bytes32",
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "buyTokenBalance",
+                        "type": "bytes32",
+                    },
+                ],
+                "internalType": "struct GPv2Order.Data",
+                "name": "order",
+                "type": "tuple",
+            },
+        ],
+        "name": "verify",
+        "outputs": [],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -47,7 +47,7 @@ def main() -> None:
         BuffersMonitoringTest(),
         CombinatorialAuctionSurplusTest(),
         UniformDirectedPricesTest(),
-        CoWAMMCommitmentTest()
+        CoWAMMCommitmentTest(),
     ]
 
     start_block: Optional[int] = None

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -27,6 +27,9 @@ from src.monitoring_tests.combinatorial_auction_surplus_test import (
 from src.monitoring_tests.uniform_directed_prices_test import (
     UniformDirectedPricesTest,
 )
+from src.monitoring_tests.cowamm_commitment_test import (
+    CoWAMMCommitmentTest,
+)
 from src.constants import SLEEP_TIME_IN_SEC
 
 
@@ -44,6 +47,7 @@ def main() -> None:
         BuffersMonitoringTest(),
         CombinatorialAuctionSurplusTest(),
         UniformDirectedPricesTest(),
+        CoWAMMCommitmentTest()
     ]
 
     start_block: Optional[int] = None

--- a/src/monitoring_tests/cowamm_commitment_test.py
+++ b/src/monitoring_tests/cowamm_commitment_test.py
@@ -1,5 +1,5 @@
 """
-Checks that surplus of CoW AMM jit orders equals nonlinear surplus.
+Checks that commitments for custom CoW AMM of CoW AMM orders are reset.
 """
 # pylint: disable=duplicate-code
 from typing import Any
@@ -17,9 +17,11 @@ COWAMM_CONSTANT_PRODUCT_ADDRESS = "0x34323B933096534e43958F6c7Bf44F2Bb59424DA".l
 
 
 class CoWAMMCommitmentTest(BaseTest):
-    """
-    This test checks whether the Uniform Directed Prices constraint,
-    as introduced in CIP-38, is satisfied.
+    """Checks that commitments for custom CoW AMM of CoW AMM orders are reset
+
+    Whenever a preinteraction calling the commit functinon of the (old) CoW AMM smart contract is
+    called, the currently commit order on the corresponding CoW AMM is checked. If the commited
+    order is not equal to the default order, the commitment was not reset.
     """
 
     def __init__(self) -> None:
@@ -31,9 +33,15 @@ class CoWAMMCommitmentTest(BaseTest):
         )
 
     def check_commitments(self, settlement: dict[str, Any]) -> bool:
-        """
-        This function checks whether there are multiple orders in the same directed token pair,
-        and if so, checks whether UDP is satisfied.
+        """Checks the commitment of CoW AMM orders.
+
+        If there is a preinteraction with a call to the commit function of the CoW AMM contant
+        product smart contract, the commitment of that AMM is checked at the current point in
+        time.
+        
+        This is not a check for including a commit in post interactions or within interactions.
+        It also does not check if the uncommit happened immediately, but just checks if the
+        current commitment is to the default order.
         """
         # iterate over pre-interactions
         for interaction in settlement["interactions"][0]:
@@ -80,8 +88,8 @@ class CoWAMMCommitmentTest(BaseTest):
 
     def run(self, tx_hash: str) -> bool:
         """
-        Wrapper function for the whole test. Checks if violation is more than
-        UDP_SENSITIVITY_THRESHOLD, in which case it generates an alert.
+        Wrapper function for the whole test. Checks that commitments for custom CoW AMM of CoW 
+        AMM orders are reset
         """
 
         transaction = self.web3_api.get_transaction(tx_hash)

--- a/src/monitoring_tests/cowamm_commitment_test.py
+++ b/src/monitoring_tests/cowamm_commitment_test.py
@@ -38,7 +38,7 @@ class CoWAMMCommitmentTest(BaseTest):
         If there is a preinteraction with a call to the commit function of the CoW AMM contant
         product smart contract, the commitment of that AMM is checked at the current point in
         time.
-        
+
         This is not a check for including a commit in post interactions or within interactions.
         It also does not check if the uncommit happened immediately, but just checks if the
         current commitment is to the default order.
@@ -88,7 +88,7 @@ class CoWAMMCommitmentTest(BaseTest):
 
     def run(self, tx_hash: str) -> bool:
         """
-        Wrapper function for the whole test. Checks that commitments for custom CoW AMM of CoW 
+        Wrapper function for the whole test. Checks that commitments for custom CoW AMM of CoW
         AMM orders are reset
         """
 

--- a/src/monitoring_tests/cowamm_commitment_test.py
+++ b/src/monitoring_tests/cowamm_commitment_test.py
@@ -1,0 +1,92 @@
+"""
+Checks that surplus of CoW AMM jit orders equals nonlinear surplus.
+"""
+# pylint: disable=duplicate-code
+from typing import Any
+
+from eth_typing import Address
+from hexbytes import HexBytes
+
+from src.monitoring_tests.base_test import BaseTest
+from src.apis.web3api import Web3API
+
+from contracts.cowamm_constantproduct import cowamm_constantproduct
+
+EMPTY_COMMITMENT = "0x0000000000000000000000000000000000000000000000000000000000000000"
+COWAMM_CONSTANT_PRODUCT_ADDRESS = "0x34323B933096534e43958F6c7Bf44F2Bb59424DA".lower()
+
+
+class CoWAMMCommitmentTest(BaseTest):
+    """
+    This test checks whether the Uniform Directed Prices constraint,
+    as introduced in CIP-38, is satisfied.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.web3_api = Web3API()
+        self.contract = self.web3_api.web_3.eth.contract(
+            address=Address(HexBytes(COWAMM_CONSTANT_PRODUCT_ADDRESS)),
+            abi=cowamm_constantproduct,
+        )
+
+    def check_commitments(self, settlement: dict[str, Any]) -> bool:
+        """
+        This function checks whether there are multiple orders in the same directed token pair,
+        and if so, checks whether UDP is satisfied.
+        """
+        # iterate over pre-interactions
+        for interaction in settlement["interactions"][0]:
+            if interaction["target"] != COWAMM_CONSTANT_PRODUCT_ADDRESS:
+                continue
+
+            cowamm_address = self.get_cowamm_address(interaction)
+
+            commitment = self.get_commitment(cowamm_address)
+            if commitment is None:
+                return False
+
+            commitment_is_reset = commitment == EMPTY_COMMITMENT
+
+            log_output = "\t".join(
+                [
+                    "CoW AMM Commitment test",
+                    f"Commitment reset: {commitment_is_reset}",
+                    f"CoW AMM: {cowamm_address}",
+                    f"Commitment: {commitment}",
+                ]
+            )
+            if not commitment_is_reset:
+                self.alert(log_output)
+            else:
+                self.logger.info(log_output)
+
+        return True
+
+    def get_cowamm_address(self, interaction: dict[str, Any]) -> str:
+        """Get the address of the CoW AMM from the commit interaction"""
+        decoded_interaction = self.contract.decode_function_input(interaction["callData"])[1]
+        cowamm_address = str(decoded_interaction["owner"])
+        return cowamm_address
+
+    def get_commitment(self, cowamm: str) -> str | None:
+        """Get the commited order for a given CoW AMM
+        It calls the commitment function in the smart contract for a given address and returns a
+        string of the format "0x...".
+        """
+        return "0x" + str(self.contract.functions.commitment(cowamm).call().hex())
+
+    def run(self, tx_hash: str) -> bool:
+        """
+        Wrapper function for the whole test. Checks if violation is more than
+        UDP_SENSITIVITY_THRESHOLD, in which case it generates an alert.
+        """
+
+        transaction = self.web3_api.get_transaction(tx_hash)
+        if transaction is None:
+            return False
+        settlement = self.web3_api.get_settlement(transaction)
+
+        success = self.check_commitments(settlement)
+
+        return success

--- a/src/monitoring_tests/cowamm_commitment_test.py
+++ b/src/monitoring_tests/cowamm_commitment_test.py
@@ -65,7 +65,9 @@ class CoWAMMCommitmentTest(BaseTest):
 
     def get_cowamm_address(self, interaction: dict[str, Any]) -> str:
         """Get the address of the CoW AMM from the commit interaction"""
-        decoded_interaction = self.contract.decode_function_input(interaction["callData"])[1]
+        decoded_interaction = self.contract.decode_function_input(
+            interaction["callData"]
+        )[1]
         cowamm_address = str(decoded_interaction["owner"])
         return cowamm_address
 

--- a/tests/e2e/cowamm_commitment_test.py
+++ b/tests/e2e/cowamm_commitment_test.py
@@ -1,0 +1,30 @@
+"""
+Tests for CoW AMM commitment test.
+"""
+
+import unittest
+from src.monitoring_tests.cowamm_commitment_test import (
+    CoWAMMCommitmentTest,
+    COWAMM_CONSTANT_PRODUCT_ADDRESS,
+)
+
+
+class TestCoWAMMCommitment(unittest.TestCase):
+    def test_cowamm_commitment(self) -> None:
+        surplus_test = CoWAMMCommitmentTest()
+        # using dummy call data which encodes one active CoW AMM
+        settlement = {
+            "interactions": [
+                [
+                    {
+                        "target": COWAMM_CONSTANT_PRODUCT_ADDRESS,
+                        "callData": "0x30f73c99000000000000000000000000beef5afe88ef73337e5070ab2855d37dbf5493a40000000000000000000000000000000000000000000000000000000000000001",
+                    }
+                ]
+            ]
+        }
+        self.assertTrue(surplus_test.check_commitments(settlement))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
With enabling phase 2 of CoW AMM, solvers can execute CoW AMM orders with custom amounts. This requires commiting and uncommiting the order in the CoW AMM smart contract. Not uncommiting the order is a violation of social consensus rules since it prevents the default order from getting executed.

This PR implements a test where after every settlement which contains a precommit interaction from the CoW AMM address the commited order for that address is checked.

Since there seem to be no commits so far, the code is a bit difficult to test. I added a test with tailored call data.