### PR TITLE
Increase buffer value test threshold

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -29,7 +29,7 @@ CAP_PARAMETER = 0.01
 BUFFER_INTERVAL = 150
 
 # threshold of value of buffers above which an alert is generated
-BUFFERS_VALUE_USD_THRESHOLD = 200000
+BUFFERS_VALUE_USD_THRESHOLD = 400000
 
 # threshold parameter to generate an alert when receiving kickbacks
 KICKBACKS_ALERT_THRESHOLD = 0.5


### PR DESCRIPTION
This PR increases the threshold for alerts in the buffers value test. The test is meant mostly as a monitoring/logging test so having a relatively low value doesn't make much sense.