### PR TITLE
Reduce MEV Blocker refunds test logs

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -32,7 +32,7 @@ BUFFER_INTERVAL = 150
 BUFFERS_VALUE_USD_THRESHOLD = 400000
 
 # threshold parameter to generate an alert when receiving kickbacks
-KICKBACKS_ALERT_THRESHOLD = 0.2
+KICKBACKS_ALERT_THRESHOLD = 0.5
 
 # threshold to generate an alert for violating UDP
 UDP_SENSITIVITY_THRESHOLD = 0.005

--- a/src/constants.py
+++ b/src/constants.py
@@ -32,7 +32,7 @@ BUFFER_INTERVAL = 150
 BUFFERS_VALUE_USD_THRESHOLD = 400000
 
 # threshold parameter to generate an alert when receiving kickbacks
-KICKBACKS_ALERT_THRESHOLD = 0.5
+KICKBACKS_ALERT_THRESHOLD = 0.2
 
 # threshold to generate an alert for violating UDP
 UDP_SENSITIVITY_THRESHOLD = 0.005

--- a/src/monitoring_tests/mev_blocker_kickbacks_test.py
+++ b/src/monitoring_tests/mev_blocker_kickbacks_test.py
@@ -53,5 +53,6 @@ class MEVBlockerRefundsMonitoringTest(BaseTest):
         if eth_kickbacks >= KICKBACKS_ALERT_THRESHOLD:
             self.alert(log_output)
         else:
-            self.logger.info(log_output)
+            if eth_kickbacks > 0:
+                self.logger.info(log_output)
         return True


### PR DESCRIPTION
Noticed that the threshold is relatively high for alerts, given the current value of ETH. Also noticed that we get a lot of meaningless logs so decided to reduce those as well.

![image](https://github.com/user-attachments/assets/73300479-2024-474c-920e-4d385321816c)
