### PR TITLE
Handle more exceptions in web3

### DIFF
--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -45,6 +45,9 @@ class Web3API:
         except ValueError as err:
             self.logger.warning(f"Error while fetching block number: {err}")
             return None
+        except Exception as err:  # pylint: disable=W0718
+            self.logger.warning(f"Exception of type {type(err)} not handled: {err}")
+            return None
 
     def get_filtered_receipts(
         self, start_block: int, end_block: int, target: str, topics: list[Any]
@@ -64,6 +67,9 @@ class Web3API:
             log_receipts = self.web_3.eth.filter(filter_criteria).get_all_entries()
         except ValueError as err:
             self.logger.warning(f"ValueError while fetching hashes: {err}")
+            return None
+        except Exception as err:  # pylint: disable=W0718
+            self.logger.warning(f"Exception of type {type(err)} not handled: {err}")
             return None
         return log_receipts
 
@@ -111,7 +117,7 @@ class Web3API:
         try:
             transaction = self.web_3.eth.get_transaction(HexStr(tx_hash))
         except Exception as err:  # pylint: disable=W0718
-            self.logger.warning(f"Error while fetching transaction: {err}")
+            self.logger.warning(f"Error of type {type(err)} while fetching transaction: {err}")
             transaction = None
         return transaction
 

--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -117,7 +117,9 @@ class Web3API:
         try:
             transaction = self.web_3.eth.get_transaction(HexStr(tx_hash))
         except Exception as err:  # pylint: disable=W0718
-            self.logger.warning(f"Error of type {type(err)} while fetching transaction: {err}")
+            self.logger.warning(
+                f"Error of type {type(err)} while fetching transaction: {err}"
+            )
             transaction = None
         return transaction
 


### PR DESCRIPTION
This PR adds handling for general exceptions in some web3 functions.

There are crashes of the EBBO pod related to fetching data using web3py. The proposed change would handle those errors more gracefully and also show which errors are raised so they can be handled more explicitly.
