### PR TITLE
Disable more tests

### DIFF
--- a/src/daemon.py
+++ b/src/daemon.py
@@ -16,12 +16,6 @@ from src.monitoring_tests.solver_competition_surplus_test import (
 from src.monitoring_tests.mev_blocker_kickbacks_test import (
     MEVBlockerRefundsMonitoringTest,
 )
-from src.monitoring_tests.combinatorial_auction_surplus_test import (
-    CombinatorialAuctionSurplusTest,
-)
-from src.monitoring_tests.uniform_directed_prices_test import (
-    UniformDirectedPricesTest,
-)
 from src.constants import SLEEP_TIME_IN_SEC
 
 

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -35,8 +35,8 @@ def main() -> None:
     tests = [
         SolverCompetitionSurplusTest(),
         MEVBlockerRefundsMonitoringTest(),
-        #CombinatorialAuctionSurplusTest(),
-        #UniformDirectedPricesTest(),
+        # CombinatorialAuctionSurplusTest(),
+        # UniformDirectedPricesTest(),
     ]
 
     start_block: Optional[int] = None

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -35,8 +35,6 @@ def main() -> None:
     tests = [
         SolverCompetitionSurplusTest(),
         MEVBlockerRefundsMonitoringTest(),
-        # CombinatorialAuctionSurplusTest(),
-        # UniformDirectedPricesTest(),
     ]
 
     start_block: Optional[int] = None

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -35,8 +35,8 @@ def main() -> None:
     tests = [
         SolverCompetitionSurplusTest(),
         MEVBlockerRefundsMonitoringTest(),
-        CombinatorialAuctionSurplusTest(),
-        UniformDirectedPricesTest(),
+        #CombinatorialAuctionSurplusTest(),
+        #UniformDirectedPricesTest(),
     ]
 
     start_block: Optional[int] = None


### PR DESCRIPTION
It was observed that the daemon has become very slow and not working as expected. For that, this PR proposes to disable the CombinatorialAuctionSurplusTest and the UniformDirectedPricesTest, as both are non-actionable, and with the hope that the daemon will start working again as expected.