### PR TITLE
Increase surplus theshold for alerts

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -6,7 +6,7 @@ All Constants that are used throughout the project
 SLEEP_TIME_IN_SEC = 10
 
 # surplus tests
-SURPLUS_ABSOLUTE_DEVIATION_ETH = 0.005
+SURPLUS_ABSOLUTE_DEVIATION_ETH = 0.05
 SURPLUS_REL_DEVIATION = 0.004
 
 # combinatorial auctions

--- a/src/monitoring_tests/solver_competition_surplus_test.py
+++ b/src/monitoring_tests/solver_competition_surplus_test.py
@@ -73,7 +73,7 @@ class SolverCompetitionSurplusTest(BaseTest):
                 ):
                     self.alert(log_output)
                 elif (
-                    a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH / 10
+                    a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH / 100
                     and a_rel > SURPLUS_REL_DEVIATION / 10
                 ):
                     self.logger.info(log_output)


### PR DESCRIPTION
This PR changes the threshold for generating alerts to 0.05ETH (up from 0.005 ETH).

Info logs are generated at 0.0005ETH as before.

The threshold is increased so that only cases which require attention create alerts. Other cases are still logged.