### PR TITLE
Fix getting transaction hash from competition data

### DIFF
--- a/src/monitoring_tests/combinatorial_auction_surplus_test.py
+++ b/src/monitoring_tests/combinatorial_auction_surplus_test.py
@@ -88,7 +88,7 @@ class CombinatorialAuctionSurplusTest(BaseTest):
         log_output = "\t".join(
             [
                 "Combinatorial auction surplus test:",
-                f"Tx Hash: {competition_data['transactionHash']}",
+                f"Tx Hash: {competition_data['transactionHashes'][0]}",
                 f"Winning Solver: {competition_data['solutions'][-1]['solver']}",
                 f"Winning surplus: {self.convert_fractions_to_floats(aggregate_solutions[-1])}",
                 f"Baseline surplus: {self.convert_fractions_to_floats(baseline_surplus)}",

--- a/src/monitoring_tests/high_score_test.py
+++ b/src/monitoring_tests/high_score_test.py
@@ -29,7 +29,7 @@ class HighScoreTest(BaseTest):
         log_output = "\t".join(
             [
                 "Large score test:",
-                f"Tx Hash: {competition_data['transactionHash']}",
+                f"Tx Hash: {competition_data['transactionHashes'][0]}",
                 f"Winning Solver: {solution['solver']}",
                 f"Score in ETH: {score}",
             ]

--- a/src/monitoring_tests/reference_solver_surplus_test.py
+++ b/src/monitoring_tests/reference_solver_surplus_test.py
@@ -75,7 +75,7 @@ class ReferenceSolverSurplusTest(BaseTest):
             log_output = "\t".join(
                 [
                     "Reference solver surplus test:",
-                    f"Tx Hash: {competition_data['transactionHash']}",
+                    f"Tx Hash: {competition_data['transactionHashes'][0]}",
                     f"Order UID: {uid}",
                     f"Winning Solver: {solution['solver']}",
                     "Solver providing more surplus: Reference solver",
@@ -85,7 +85,7 @@ class ReferenceSolverSurplusTest(BaseTest):
             )
             ref_solver_log = "\t".join(
                 [
-                    f"Tx Hash: {competition_data['transactionHash']}",
+                    f"Tx Hash: {competition_data['transactionHashes'][0]}",
                     f"Order UID: {uid}",
                     f"Solution providing more surplus: {ref_solver_response}",
                 ]

--- a/src/monitoring_tests/solver_competition_surplus_test.py
+++ b/src/monitoring_tests/solver_competition_surplus_test.py
@@ -58,7 +58,7 @@ class SolverCompetitionSurplusTest(BaseTest):
                 log_output = "\t".join(
                     [
                         "Solver competition surplus test:",
-                        f"Tx Hash: {competition_data['transactionHash']}",
+                        f"Tx Hash: {competition_data['transactionHashes'][0]}",
                         f"Order UID: {uid}",
                         f"Winning Solver: {solution['solver']}",
                         f"Solver providing more surplus: {solver_alt}",

--- a/src/monitoring_tests/uniform_directed_prices_test.py
+++ b/src/monitoring_tests/uniform_directed_prices_test.py
@@ -55,7 +55,7 @@ class UniformDirectedPricesTest(BaseTest):
             log_output = "\t".join(
                 [
                     "Uniform Directed Prices test:",
-                    f"Tx Hash: {competition_data['transactionHash']}",
+                    f"Tx Hash: {competition_data['transactionHashes'][0]}",
                     f"Winning Solver: {solution['solver']}",
                     f"Token pair: {pair}",
                     f"Directional prices: {[float(p) for p in prices_list]}",


### PR DESCRIPTION
This PR changes how transaction hashes are fetched from competition data.

To support multiple winners, the competition data format was changed to allow for multiple transactions to be associated to an auction. This meant, that instead of a `"transactionHash"` field containing a string, a `"transactionHashes"` field containing a vector of strings is stored. This PR, changes the code to use the new convention.