### PR TITLE
Fix MEV Blocker kickbacks test

### DIFF
--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -103,9 +103,8 @@ class Web3API:
             return None
         total_transfers_in_eth = 0.0
         for txs in log_receipts:
-            if (
-                txs["topics"][0].hex()
-                == "0x3d0ce9bfc3ed7d6862dbb28b2dea94561fe714a1b4d019aa8af39730d1ad7c3d"
+            if txs["topics"][0] == HexBytes(
+                "0x3d0ce9bfc3ed7d6862dbb28b2dea94561fe714a1b4d019aa8af39730d1ad7c3d"
             ):
                 total_transfers_in_eth += int(txs["data"].hex(), 16) / 10**18
         return total_transfers_in_eth

--- a/tests/e2e/mev_blocker_kickbacks_test.py
+++ b/tests/e2e/mev_blocker_kickbacks_test.py
@@ -1,5 +1,5 @@
 """
-Tests for large score test.
+Test for MEV Blocker kickbacks test.
 """
 
 import unittest
@@ -8,16 +8,16 @@ from src.monitoring_tests.mev_blocker_kickbacks_test import (
 )
 
 
-class TestHighScore(unittest.TestCase):
-    def test_high_score(self) -> None:
-        high_score_test = MEVBlockerRefundsMonitoringTest()
+class TestMevBlockerRefunds(unittest.TestCase):
+    def test_mev_blocker_refunds(self) -> None:
+        mev_blocker_refunds_test = MEVBlockerRefundsMonitoringTest()
         # large kickback tx
         tx_hash = "0xcbf4677177fb320b7e000ca95b31b5259648c75ebcfa9544014298ddfea94282"
-        self.assertTrue(high_score_test.run(tx_hash))
+        self.assertTrue(mev_blocker_refunds_test.run(tx_hash))
 
         # no kickback tx
         tx_hash = "0x3198bc18bc41ec3eb35cc382697d18917ebdaf03528e7dcc5270488d156037c8"
-        self.assertTrue(high_score_test.run(tx_hash))
+        self.assertTrue(mev_blocker_refunds_test.run(tx_hash))
 
 
 if __name__ == "__main__":

--- a/tests/e2e/mev_blocker_kickbacks_test.py
+++ b/tests/e2e/mev_blocker_kickbacks_test.py
@@ -1,0 +1,24 @@
+"""
+Tests for large score test.
+"""
+
+import unittest
+from src.monitoring_tests.mev_blocker_kickbacks_test import (
+    MEVBlockerRefundsMonitoringTest,
+)
+
+
+class TestHighScore(unittest.TestCase):
+    def test_high_score(self) -> None:
+        high_score_test = MEVBlockerRefundsMonitoringTest()
+        # large kickback tx
+        tx_hash = "0xcbf4677177fb320b7e000ca95b31b5259648c75ebcfa9544014298ddfea94282"
+        self.assertTrue(high_score_test.run(tx_hash))
+
+        # no kickback tx
+        tx_hash = "0x3198bc18bc41ec3eb35cc382697d18917ebdaf03528e7dcc5270488d156037c8"
+        self.assertTrue(high_score_test.run(tx_hash))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@fhenneke observed that high MEV Blocker refund alerts were missing. Had a look and it turns out that a topic check

```
       txs["topics"][0].hex()  == "0x3d0ce9bfc3ed7d6862dbb28b2dea94561fe714a1b4d019aa8af39730d1ad7c3d"
```
started failing because the left-hand side didn't have the prefix "0x".

Not sure why this stopped working, but in any case, this PR proposes a slightly more robust way of doing the check.

Also added a test to demonstrate the fix works. Again, the only meaningful way of running the test is by having it print the logs as well

` python -m pytest --log-cli-level=DEBUG tests/e2e/mev_blocker_kickbacks_test.py`