### PR TITLE
Use custom log filter to send info to stdout and error to stderr

### DIFF
--- a/src/apis/auctioninstanceapi.py
+++ b/src/apis/auctioninstanceapi.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 import json
 import requests
 from src.models import OrderData
-from src.helper_functions import get_logger
+from src.helper_functions import Logger
 from src.constants import (
     header,
     REQUEST_TIMEOUT,
@@ -31,7 +31,7 @@ class AuctionInstanceAPI:
     """
 
     def __init__(self) -> None:
-        self.logger = get_logger()
+        self.logger = Logger()
 
     def get_auction_instance(self, auction_id: int) -> Optional[dict[str, Any]]:
         """

--- a/src/apis/coingeckoapi.py
+++ b/src/apis/coingeckoapi.py
@@ -6,7 +6,7 @@ CoingeckoAPI for fetching the price in usd of a given token.
 
 from typing import Optional
 import requests
-from src.helper_functions import get_logger
+from src.helper_functions import Logger
 from src.constants import (
     header,
     REQUEST_TIMEOUT,
@@ -19,7 +19,7 @@ class CoingeckoAPI:
     """
 
     def __init__(self) -> None:
-        self.logger = get_logger()
+        self.logger = Logger()
 
     def get_token_price_in_usd(self, address: str) -> Optional[float]:
         """

--- a/src/apis/orderbookapi.py
+++ b/src/apis/orderbookapi.py
@@ -7,7 +7,7 @@ OrderbookAPI for fetching relevant data using the CoW Swap Orderbook API.
 from typing import Any, Optional
 import json
 import requests
-from src.helper_functions import get_logger
+from src.helper_functions import Logger
 from src.models import Trade, OrderData, OrderExecution
 from src.constants import (
     header,
@@ -26,7 +26,7 @@ class OrderbookAPI:
     """
 
     def __init__(self) -> None:
-        self.logger = get_logger()
+        self.logger = Logger()
 
     def get_solver_competition_data(self, tx_hash: str) -> Optional[dict[str, Any]]:
         """

--- a/src/apis/solverapi.py
+++ b/src/apis/solverapi.py
@@ -10,7 +10,7 @@ import json
 import requests
 from dotenv import load_dotenv
 from src.models import OrderExecution
-from src.helper_functions import get_logger
+from src.helper_functions import Logger
 from src.constants import (
     header,
     REQUEST_TIMEOUT,
@@ -24,7 +24,7 @@ class SolverAPI:
     """
 
     def __init__(self, url: Optional[str] = None) -> None:
-        self.logger = get_logger()
+        self.logger = Logger()
         if url is None:
             load_dotenv()
             self.solver_url = getenv("QUASIMODO_SOLVER_URL")

--- a/src/apis/tenderlyapi.py
+++ b/src/apis/tenderlyapi.py
@@ -8,7 +8,7 @@ from os import getenv
 from typing import Any, Optional
 import requests
 from dotenv import load_dotenv
-from src.helper_functions import get_logger
+from src.helper_functions import Logger
 from src.constants import (
     SETTLEMENT_CONTRACT_ADDRESS,
     REQUEST_TIMEOUT,
@@ -21,7 +21,7 @@ class TenderlyAPI:
     """
 
     def __init__(self) -> None:
-        self.logger = get_logger()
+        self.logger = Logger()
         load_dotenv()
         self.tenderly_url = (
             "https://api.tenderly.co/api/v1/account/"

--- a/src/apis/tokenlistapi.py
+++ b/src/apis/tokenlistapi.py
@@ -5,7 +5,7 @@ TokenListAPI for fetching a curated token list.
 # pylint: disable=logging-fstring-interpolation
 from typing import Optional
 import requests
-from src.helper_functions import get_logger
+from src.helper_functions import Logger
 from src.constants import (
     header,
     REQUEST_TIMEOUT,
@@ -18,7 +18,7 @@ class TokenListAPI:
     """
 
     def __init__(self) -> None:
-        self.logger = get_logger()
+        self.logger = Logger()
         self.token_lists = [
             "http://t2crtokens.eth.link",
             "https://tokens.1inch.eth.link",

--- a/src/apis/web3api.py
+++ b/src/apis/web3api.py
@@ -14,7 +14,7 @@ from eth_typing import Address, HexStr
 from hexbytes import HexBytes
 from contracts.gpv2_settlement import gpv2_settlement
 from src.models import Trade, OrderData, OrderExecution
-from src.helper_functions import get_logger
+from src.helper_functions import Logger
 from src.constants import SETTLEMENT_CONTRACT_ADDRESS
 
 
@@ -34,7 +34,7 @@ class Web3API:
         self.contract = self.web_3.eth.contract(
             address=Address(HexBytes(SETTLEMENT_CONTRACT_ADDRESS)), abi=gpv2_settlement
         )
-        self.logger = get_logger()
+        self.logger = Logger()
 
     def get_current_block_number(self) -> Optional[int]:
         """

--- a/src/monitoring_tests/base_test.py
+++ b/src/monitoring_tests/base_test.py
@@ -8,7 +8,7 @@ for all tests developed.
 import os
 from abc import ABC, abstractmethod
 from slack_sdk import WebClient
-from src.helper_functions import get_logger
+from src.helper_functions import Logger
 
 
 class BaseTest(ABC):
@@ -20,7 +20,7 @@ class BaseTest(ABC):
 
     def __init__(self) -> None:
         self.tx_hashes: list[str] = []
-        self.logger = get_logger()
+        self.logger = Logger()
 
         if "SLACK_BOT_TOKEN" in os.environ:
             self.slack_client = WebClient(token=os.environ["SLACK_BOT_TOKEN"])


### PR DESCRIPTION
This PR updates the logging to use a custom log filter. This sends all debug and info logs to stdout and all other (error) logs to stderr.

You can test this by running the code with `python3 -m tests.e2e.test 1>stdout.log 2>stderr.log`. All info level logs should appear in `stdout.log` and all logs that are classified as warning or above should go to `stderr.log`.