### PR TITLE
Add per chain thresholds

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -6,11 +6,21 @@ All Constants that are used throughout the project
 SLEEP_TIME_IN_SEC = 10
 
 # surplus tests
-SURPLUS_ABSOLUTE_DEVIATION_ETH = 0.05
+SURPLUS_ABSOLUTE_DEVIATION_NATIVE_TOKEN = {
+    "mainnet": 0.05,
+    "xdai": 10,
+    "arbitrum_one": 0.01,
+    "base": 0.01,
+}
 SURPLUS_REL_DEVIATION = 0.004
 
 # combinatorial auctions
-COMBINATORIAL_AUCTION_ABSOLUTE_DEVIATION_ETH = 0.005
+COMBINATORIAL_AUCTION_ABSOLUTE_DEVIATION_NATIVE_TOKEN = {
+    "mainnet": 0.005,
+    "xdai": 10,
+    "arbitrum_one": 0.005,
+    "base": 0.005,
+}
 
 # cost coverage test
 COST_COVERAGE_ABSOLUTE_DEVIATION_ETH = 0.01
@@ -38,7 +48,12 @@ KICKBACKS_ALERT_THRESHOLD = 0.5
 UDP_SENSITIVITY_THRESHOLD = 0.005
 
 # threshold to generate an alert for high score
-HIGH_SCORE_THRESHOLD_ETH = 10
+HIGH_SCORE_THRESHOLD_NATIVE_TOKEN = {
+    "mainnet": 10,
+    "xdai": 100,
+    "arbitrum_one": 1,
+    "base": 1,
+}
 
 # relevant addresses
 SETTLEMENT_CONTRACT_ADDRESS = "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -34,8 +34,8 @@ def main() -> None:
 
     # initialize tests
     tests = [
-        SolverCompetitionSurplusTest(orderbook_api),
-        HighScoreTest(orderbook_api),
+        SolverCompetitionSurplusTest(orderbook_api, chain_name),
+        HighScoreTest(orderbook_api, chain_name),
     ]
     # special case for mainnet as MEV Blocker only exists on mainnet
     if chain_name == "mainnet":

--- a/src/monitoring_tests/combinatorial_auction_surplus_test.py
+++ b/src/monitoring_tests/combinatorial_auction_surplus_test.py
@@ -10,8 +10,8 @@ from fractions import Fraction
 from src.monitoring_tests.base_test import BaseTest
 from src.apis.orderbookapi import OrderbookAPI
 from src.constants import (
-    SURPLUS_ABSOLUTE_DEVIATION_ETH,
-    COMBINATORIAL_AUCTION_ABSOLUTE_DEVIATION_ETH,
+    SURPLUS_ABSOLUTE_DEVIATION_NATIVE_TOKEN,
+    COMBINATORIAL_AUCTION_ABSOLUTE_DEVIATION_NATIVE_TOKEN,
 )
 
 
@@ -35,9 +35,10 @@ class CombinatorialAuctionSurplusTest(BaseTest):
       with our current mechanism.
     """
 
-    def __init__(self, orderbook_api: OrderbookAPI) -> None:
+    def __init__(self, orderbook_api: OrderbookAPI, chain_name: str) -> None:
         super().__init__()
         self.orderbook_api = orderbook_api
+        self.chain_name = chain_name
 
     def run_combinatorial_auction(self, competition_data: dict[str, Any]) -> bool:
         """Run combinatorial auction on competition data.
@@ -103,12 +104,13 @@ class CombinatorialAuctionSurplusTest(BaseTest):
 
         if any(
             solutions[ind]["solver"] == "baseline"
-            and surplus_difference > COMBINATORIAL_AUCTION_ABSOLUTE_DEVIATION_ETH
+            and surplus_difference
+            > COMBINATORIAL_AUCTION_ABSOLUTE_DEVIATION_NATIVE_TOKEN[self.chain_name]
             for ind, surplus_difference in filter_mask[-1]
         ):
             self.alert(log_output)
         elif (
-            a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH / 10
+            a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_NATIVE_TOKEN[self.chain_name] / 10
             or not len(filter_mask[-1]) == 0
         ):
             self.logger.info(log_output)

--- a/src/monitoring_tests/high_score_test.py
+++ b/src/monitoring_tests/high_score_test.py
@@ -7,7 +7,7 @@ Checking winner's score and generating an alert if score is very large
 from typing import Any
 from src.monitoring_tests.base_test import BaseTest
 from src.apis.orderbookapi import OrderbookAPI
-from src.constants import HIGH_SCORE_THRESHOLD_ETH
+from src.constants import HIGH_SCORE_THRESHOLD_NATIVE_TOKEN
 
 
 class HighScoreTest(BaseTest):
@@ -16,9 +16,10 @@ class HighScoreTest(BaseTest):
     is above certain threshold
     """
 
-    def __init__(self, orderbook_api: OrderbookAPI) -> None:
+    def __init__(self, orderbook_api: OrderbookAPI, chain_name: str) -> None:
         super().__init__()
         self.orderbook_api = orderbook_api
+        self.chain_name = chain_name
 
     def compute_winning_score(self, competition_data: dict[str, Any]) -> bool:
         """
@@ -34,7 +35,7 @@ class HighScoreTest(BaseTest):
                 f"Score in ETH: {score}",
             ]
         )
-        if score > HIGH_SCORE_THRESHOLD_ETH:
+        if score > HIGH_SCORE_THRESHOLD_NATIVE_TOKEN[self.chain_name]:
             self.alert(log_output)
         return True
 

--- a/src/monitoring_tests/reference_solver_surplus_test.py
+++ b/src/monitoring_tests/reference_solver_surplus_test.py
@@ -13,7 +13,7 @@ from src.apis.orderbookapi import OrderbookAPI
 from src.apis.auctioninstanceapi import AuctionInstanceAPI
 from src.apis.solverapi import SolverAPI
 from src.models import Trade
-from src.constants import SURPLUS_ABSOLUTE_DEVIATION_ETH, SURPLUS_REL_DEVIATION
+from src.constants import SURPLUS_ABSOLUTE_DEVIATION_NATIVE_TOKEN, SURPLUS_REL_DEVIATION
 
 
 class ReferenceSolverSurplusTest(BaseTest):
@@ -22,10 +22,13 @@ class ReferenceSolverSurplusTest(BaseTest):
     the executions of these orders by a reference solver.
     """
 
-    def __init__(self, web3_api: Web3API, orderbook_api: OrderbookAPI) -> None:
+    def __init__(
+        self, web3_api: Web3API, orderbook_api: OrderbookAPI, chain_name: str
+    ) -> None:
         super().__init__()
         self.web3_api = web3_api
         self.orderbook_api = orderbook_api
+        self.chain_name = chain_name
         self.auction_instance_api = AuctionInstanceAPI()
         self.solver_api = SolverAPI()
 
@@ -92,13 +95,14 @@ class ReferenceSolverSurplusTest(BaseTest):
             )
 
             if (
-                a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH
+                a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_NATIVE_TOKEN[self.chain_name]
                 and a_rel > SURPLUS_REL_DEVIATION
             ):
                 self.logger.info(log_output)
                 self.logger.info(ref_solver_log)
             elif (
-                a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH / 10
+                a_abs_eth
+                > SURPLUS_ABSOLUTE_DEVIATION_NATIVE_TOKEN[self.chain_name] / 10
                 and a_rel > SURPLUS_REL_DEVIATION / 10
             ):
                 self.logger.info(log_output)

--- a/src/monitoring_tests/solver_competition_surplus_test.py
+++ b/src/monitoring_tests/solver_competition_surplus_test.py
@@ -9,7 +9,7 @@ from fractions import Fraction
 from src.monitoring_tests.base_test import BaseTest
 from src.apis.orderbookapi import OrderbookAPI
 from src.models import Trade, OrderExecution
-from src.constants import SURPLUS_ABSOLUTE_DEVIATION_ETH, SURPLUS_REL_DEVIATION
+from src.constants import SURPLUS_ABSOLUTE_DEVIATION_NATIVE_TOKEN, SURPLUS_REL_DEVIATION
 
 
 class SolverCompetitionSurplusTest(BaseTest):
@@ -18,9 +18,10 @@ class SolverCompetitionSurplusTest(BaseTest):
     the different executions of these orders by other solvers in the competition.
     """
 
-    def __init__(self, orderbook_api: OrderbookAPI) -> None:
+    def __init__(self, orderbook_api: OrderbookAPI, chain_name: str) -> None:
         super().__init__()
         self.orderbook_api = orderbook_api
+        self.chain_name = chain_name
 
     def compare_orders_surplus(self, competition_data: dict[str, Any]) -> bool:
         """
@@ -68,12 +69,13 @@ class SolverCompetitionSurplusTest(BaseTest):
                 )
 
                 if (
-                    a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH
+                    a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_NATIVE_TOKEN[self.chain_name]
                     and a_rel > SURPLUS_REL_DEVIATION
                 ):
                     self.alert(log_output)
                 elif (
-                    a_abs_eth > SURPLUS_ABSOLUTE_DEVIATION_ETH / 100
+                    a_abs_eth
+                    > SURPLUS_ABSOLUTE_DEVIATION_NATIVE_TOKEN[self.chain_name] / 100
                     and a_rel > SURPLUS_REL_DEVIATION / 10
                 ):
                     self.logger.info(log_output)


### PR DESCRIPTION
This PR adjusts the thresholds used for tests on a per chain basis. This is now relevant since EBBO has been deployed on all cains.